### PR TITLE
Fixes Environment Import Error

### DIFF
--- a/api/src/utils/Logger.ts
+++ b/api/src/utils/Logger.ts
@@ -1,8 +1,9 @@
 import winston from "winston";
-import { environment } from "..";
+
+const { NODE_ENV } = process.env;
 
 const Logger = winston.createLogger({
-  level: environment === "development" ? "debug" : "warn",
+  level: NODE_ENV === "development" ? "debug" : "warn",
   format: winston.format.combine(
     winston.format.timestamp(),
     winston.format.json(),


### PR DESCRIPTION
- Replaced use of `environment` within `Logger` with `NODE_ENV`.
- Removed erroneous `import { environment } from '..';`
- Fixes error of `AssetController_1.default is not a constructor`.