### PR TITLE
Database lazy singleton

### DIFF
--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -1,5 +1,4 @@
 import { QueryInterface, Sequelize } from "sequelize";
-import "ts-node/register";
 import { SequelizeStorage, Umzug } from "umzug";
 import ErrorController from "../../controllers/ErrorController";
 import Logger from "../../utils/Logger";
@@ -8,39 +7,6 @@ interface DatabaseClient {
   sequelize: Sequelize;
   Sequelize: typeof Sequelize;
 }
-
-/*const database = process.env.API_DATABASE_NAME;
-const username = process.env.API_DATABASE_USERNAME;
-const password = process.env.API_DATABASE_PASSWORD;
-const host = process.env.API_DATABASE_HOST;
-
-if (!database || !username || !password || !host) {
-  console.error(`Unable to load database credentials`);
-}
-
-const connectionUrl: string = `postgres://${username}:${password}@${host}:5432/${database}`;
-
-//Logging is temp until Logging EPIC
-const sequelize = new Sequelize(connectionUrl, {
-  logging: (...msg) => console.log(`Database log: ${msg}`),
-});
-
-export const db: DatabaseClient = {
-  sequelize,
-  Sequelize,
-};
-
-export const migrator = new Umzug({
-  migrations: {
-    glob: "src/database/migrations/*.ts",
-  },
-  context: sequelize.getQueryInterface(),
-  storage: new SequelizeStorage({ sequelize: db.sequelize }),
-  logger: console,
-});
-
-export type Migration = typeof migrator._types.migration;
-*/
 
 let connectionUrl: string | undefined;
 let sequelize: Sequelize | undefined;
@@ -55,7 +21,7 @@ const getConnectionUrl = (): string => {
   const host = process.env.API_DATABASE_HOST;
   if (!database || !username || !password || !host) {
     Logger.error("Unable to load database credentials");
-    throw ErrorController.InternalServerError();
+    throw ErrorController.InternalServerError("No database connection");
   }
   connectionUrl = `postgres://${username}:${password}@${host}:5432/${database}`;
   return connectionUrl;

--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -22,7 +22,7 @@ const getConnectionUrl = (): string => {
   const host = process.env.API_DATABASE_HOST;
   if (!database || !username || !password || !host) {
     Logger.error("Unable to load database credentials");
-    throw ErrorController.InternalServerError("No database connection");
+    throw ErrorController.InternalServerError();
   }
   connectionUrl = `postgres://${username}:${password}@${host}:5432/${database}`;
   return connectionUrl;

--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -1,13 +1,15 @@
-import { Sequelize } from "sequelize";
+import { QueryInterface, Sequelize } from "sequelize";
 import "ts-node/register";
 import { SequelizeStorage, Umzug } from "umzug";
+import ErrorController from "../../controllers/ErrorController";
+import Logger from "../../utils/Logger";
 
 interface DatabaseClient {
   sequelize: Sequelize;
   Sequelize: typeof Sequelize;
 }
 
-const database = process.env.API_DATABASE_NAME;
+/*const database = process.env.API_DATABASE_NAME;
 const username = process.env.API_DATABASE_USERNAME;
 const password = process.env.API_DATABASE_PASSWORD;
 const host = process.env.API_DATABASE_HOST;
@@ -38,3 +40,56 @@ export const migrator = new Umzug({
 });
 
 export type Migration = typeof migrator._types.migration;
+*/
+
+let connectionUrl: string | undefined;
+let sequelize: Sequelize | undefined;
+let db: DatabaseClient | undefined;
+let migrator: Umzug<QueryInterface> | undefined;
+
+const getConnectionUrl = (): string => {
+  if (connectionUrl !== undefined) return connectionUrl;
+  const database = process.env.API_DATABASE_NAME;
+  const username = process.env.API_DATABASE_USERNAME;
+  const password = process.env.API_DATABASE_PASSWORD;
+  const host = process.env.API_DATABASE_HOST;
+  if (!database || !username || !password || !host) {
+    Logger.error("Unable to load database credentials");
+    throw ErrorController.InternalServerError();
+  }
+  connectionUrl = `postgres://${username}:${password}@${host}:5432/${database}`;
+  return connectionUrl;
+};
+
+export const getSequelizeConnection = (): Sequelize => {
+  if (sequelize !== undefined) return sequelize;
+  sequelize = new Sequelize(getConnectionUrl(), {
+    logging: (...msg) => Logger.info(msg),
+  });
+  return sequelize;
+};
+
+export const getDb = (): DatabaseClient => {
+  if (db !== undefined) return db;
+  db = {
+    sequelize: getSequelizeConnection(),
+    Sequelize
+  };
+  return db;
+};
+
+export const getMigrator = (): Umzug<QueryInterface> => {
+  if (migrator !== undefined) return migrator;
+  const sequelize = getSequelizeConnection();
+  migrator = new Umzug({
+    migrations: {
+      glob: "src/database/migrations/*.migration.ts",
+    },
+    context: sequelize.getQueryInterface(),
+    storage: new SequelizeStorage({ sequelize }),
+    logger: Logger,
+  });
+  return migrator;
+};
+
+export type Migration = typeof Umzug.prototype._types.migration;

--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -1,3 +1,4 @@
+import "ts-node/register";
 import { QueryInterface, Sequelize } from "sequelize";
 import { SequelizeStorage, Umzug } from "umzug";
 import ErrorController from "../../controllers/ErrorController";

--- a/api/src/database/migrations/initial.migration.ts
+++ b/api/src/database/migrations/initial.migration.ts
@@ -1,4 +1,4 @@
-import { Migration } from "../config/databaseClient";
+import type { Migration } from "../config/databaseClient";
 import { DataTypes } from "sequelize";
 
 export const up: Migration = async ({ context: queryInterface }) => {

--- a/api/src/database/models/asset.model.ts
+++ b/api/src/database/models/asset.model.ts
@@ -21,6 +21,7 @@ class Asset extends Model<
   declare updatedAt: CreationOptional<Date>;
 }
 
+export const init = () => {
 Asset.init(
   {
     id: {
@@ -63,5 +64,6 @@ Asset.init(
     sequelize: getSequelizeConnection(),
   }
 );
+};
 
 export default Asset;

--- a/api/src/database/models/asset.model.ts
+++ b/api/src/database/models/asset.model.ts
@@ -5,7 +5,7 @@ import {
   InferCreationAttributes,
   Model,
 } from "sequelize";
-import { db } from "../config/databaseClient";
+import { getSequelizeConnection } from "../config/databaseClient";
 
 class Asset extends Model<
   InferAttributes<Asset>,
@@ -60,7 +60,7 @@ Asset.init(
   },
   {
     tableName: "assets",
-    sequelize: db.sequelize,
+    sequelize: getSequelizeConnection(),
   }
 );
 

--- a/api/src/database/models/asset.model.ts
+++ b/api/src/database/models/asset.model.ts
@@ -22,48 +22,48 @@ class Asset extends Model<
 }
 
 export const init = () => {
-Asset.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      primaryKey: true,
-      allowNull: false,
-      autoIncrement: true,
+  Asset.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        allowNull: false,
+        autoIncrement: true,
+      },
+      assetTag: {
+        type: DataTypes.STRING(128),
+        allowNull: false,
+      },
+      name: {
+        type: DataTypes.STRING(128),
+        allowNull: false,
+      },
+      serialNumber: {
+        type: DataTypes.STRING(128),
+        allowNull: true,
+      },
+      modelNumber: {
+        type: DataTypes.STRING(128),
+        allowNull: true
+      },
+      nextAuditDate: {
+        type: DataTypes.DATE,
+        allowNull: true
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
     },
-    assetTag: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-    },
-    name: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-    },
-    serialNumber: {
-      type: DataTypes.STRING(128),
-      allowNull: true,
-    },
-    modelNumber: {
-      type: DataTypes.STRING(128),
-      allowNull: true
-    },
-    nextAuditDate: {
-      type: DataTypes.DATE,
-      allowNull: true
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-  },
-  {
-    tableName: "assets",
-    sequelize: getSequelizeConnection(),
-  }
-);
+    {
+      tableName: "assets",
+      sequelize: getSequelizeConnection(),
+    }
+  );
 };
 
 export default Asset;

--- a/api/src/database/models/location.model.ts
+++ b/api/src/database/models/location.model.ts
@@ -19,39 +19,41 @@ class Location extends Model<
   declare updatedAt: CreationOptional<Date>;
 }
 
-Location.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      primaryKey: true,
-      allowNull: false,
-      autoIncrement: true,
+export const init = () => {
+  Location.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        allowNull: false,
+        autoIncrement: true,
+      },
+      locationName: {
+        type: DataTypes.STRING(128),
+        allowNull: false,
+      },
+      geoLocation: {
+        type: DataTypes.JSON,
+        allowNull: true,
+      },
+      primaryLocation: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
     },
-    locationName: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-    },
-    geoLocation: {
-      type: DataTypes.JSON,
-      allowNull: true,
-    },
-    primaryLocation: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-  },
-  {
-    tableName: "locations",
-    sequelize: getSequelizeConnection(),
-  }
-);
+    {
+      tableName: "locations",
+      sequelize: getSequelizeConnection(),
+    }
+  );
+};
 
 export default Location;

--- a/api/src/database/models/location.model.ts
+++ b/api/src/database/models/location.model.ts
@@ -5,7 +5,7 @@ import {
   InferCreationAttributes,
   Model,
 } from "sequelize";
-import { db } from "../config/databaseClient";
+import { getSequelizeConnection } from "../config/databaseClient";
 
 class Location extends Model<
   InferAttributes<Location>,
@@ -50,7 +50,7 @@ Location.init(
   },
   {
     tableName: "locations",
-    sequelize: db.sequelize,
+    sequelize: getSequelizeConnection(),
   }
 );
 

--- a/api/src/database/models/settings.model.ts
+++ b/api/src/database/models/settings.model.ts
@@ -5,7 +5,7 @@ import {
   Model,
   DataTypes,
 } from "sequelize";
-import { db } from "../config/databaseClient";
+import { getSequelizeConnection } from "../config/databaseClient";
 
 class Settings extends Model<
   InferAttributes<Settings>,
@@ -34,6 +34,6 @@ Settings.init(
   },
   {
     tableName: "settings",
-    sequelize: db.sequelize,
+    sequelize: getSequelizeConnection(),
   }
 );

--- a/api/src/database/models/settings.model.ts
+++ b/api/src/database/models/settings.model.ts
@@ -16,24 +16,28 @@ class Settings extends Model<
   declare categoryData: JSON;
 }
 
-Settings.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
+export const init = () => {
+  Settings.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      category: {
+        type: DataTypes.STRING(128),
+        allowNull: false,
+      },
+      categoryData: {
+        type: DataTypes.JSON,
+        allowNull: false,
+      },
     },
-    category: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-    },
-    categoryData: {
-      type: DataTypes.JSON,
-      allowNull: false,
-    },
-  },
-  {
-    tableName: "settings",
-    sequelize: getSequelizeConnection(),
-  }
-);
+    {
+      tableName: "settings",
+      sequelize: getSequelizeConnection(),
+    }
+  );
+};
+
+export default Settings;

--- a/api/src/database/models/user.model.ts
+++ b/api/src/database/models/user.model.ts
@@ -21,54 +21,56 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare updatedAt: CreationOptional<Date>;
 }
 
-User.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
+export const init = () => {
+  User.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      firstName: {
+        type: DataTypes.STRING(128),
+        allowNull: false,
+      },
+      lastName: {
+        type: DataTypes.STRING(128),
+        allowNull: false,
+      },
+      username: {
+        type: DataTypes.STRING(128),
+        allowNull: false,
+      },
+      password: {
+        type: DataTypes.STRING(128),
+        allowNull: false,
+      },    
+      email: {
+        type: DataTypes.STRING(128),
+        allowNull: false,
+      },
+      isActive: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+      },
+      scopes: {
+        type: DataTypes.ARRAY(DataTypes.STRING),
+        allowNull: false,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
     },
-    firstName: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-    },
-    lastName: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-    },
-    username: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-    },
-    password: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-    },    
-    email: {
-      type: DataTypes.STRING(128),
-      allowNull: false,
-    },
-    isActive: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-    },
-    scopes: {
-      type: DataTypes.ARRAY(DataTypes.STRING),
-      allowNull: false,
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-  },
-  {
-    tableName: "users",
-    sequelize: getSequelizeConnection(),
-  }
-);
+    {
+      tableName: "users",
+      sequelize: getSequelizeConnection(),
+    }
+  );
+};
 
 export default User;

--- a/api/src/database/models/user.model.ts
+++ b/api/src/database/models/user.model.ts
@@ -5,7 +5,7 @@ import {
   InferCreationAttributes,
   Model,
 } from "sequelize";
-import { db } from "../config/databaseClient";
+import { getSequelizeConnection } from "../config/databaseClient";
 import { Scope } from "../../utils/types/attributeTypes";
 
 class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
@@ -67,7 +67,7 @@ User.init(
   },
   {
     tableName: "users",
-    sequelize: db.sequelize,
+    sequelize: getSequelizeConnection(),
   }
 );
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -34,7 +34,7 @@ const startupConfiguration = async () => {
   const redisClient = getRedisClient();
   await Promise.all([
     migrator.up(),
-	redisClient.connect(),
+    redisClient.connect(),
   ]);
 };
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import express, { Express } from "express";
 import { getMigrator } from "./database/config/databaseClient";
-import { redisClient } from "./database/config/redisClient";
+import { getRedisClient } from "./database/config/redisClient";
 import cors from "cors";
 import helmet from "helmet";
 import assetsRouter from "./routes/AssetRouter";
@@ -31,8 +31,11 @@ app.use(errorHandler);
 
 const startupConfiguration = async () => {
   const migrator = getMigrator();
-  await migrator.up();
-  await redisClient.connect();
+  const redisClient = getRedisClient();
+  await Promise.all([
+    migrator.up(),
+	redisClient.connect(),
+  ]);
 };
 
 app.listen(port, () => {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import express, { Express } from "express";
-import { migrator } from "./database/config/databaseClient";
+import { getMigrator } from "./database/config/databaseClient";
 import { redisClient } from "./database/config/redisClient";
 import cors from "cors";
 import helmet from "helmet";
@@ -30,6 +30,7 @@ app.use("/auth", authRouter);
 app.use(errorHandler);
 
 const startupConfiguration = async () => {
+  const migrator = getMigrator();
   await migrator.up();
   await redisClient.connect();
 };

--- a/api/src/middlewares/errorHandler.ts
+++ b/api/src/middlewares/errorHandler.ts
@@ -16,7 +16,7 @@ export const errorHandler = (
 
   res.status(statusCode).json({
     error: {
-      message: message,
+      message,
     },
   });
 };

--- a/api/src/middlewares/requestRateLimiter.ts
+++ b/api/src/middlewares/requestRateLimiter.ts
@@ -1,9 +1,10 @@
 import { Request, Response, NextFunction } from "express";
 import { RateLimiterRedis } from "rate-limiter-flexible";
-import { redisClient } from "../database/config/redisClient";
+import { getRedisClient } from "../database/config/redisClient";
+import Logger from "../utils/Logger";
 
 const rateLimiter = new RateLimiterRedis({
-    storeClient: redisClient,
+    storeClient: getRedisClient(),
     keyPrefix: 'middleware',
     points: 10,
     duration: 1,
@@ -13,7 +14,8 @@ const rateLimiter = new RateLimiterRedis({
 const rateLimiterMiddleware = (req: Request, res: Response, next: NextFunction) => {
     rateLimiter.consume(req.ip ?? 'Unknown').then(() => {
         next();
-    }).catch(() => {
+    }).catch((reason: string) => {
+        Logger.info(`RateLimitReason: ${reason}`);
         res.status(429).send('Too Many Requests');
     });
 };

--- a/api/src/services/AssetService.ts
+++ b/api/src/services/AssetService.ts
@@ -1,4 +1,4 @@
-import Asset from "../database/models/asset.model";
+import Asset, { init } from "../database/models/asset.model";
 import { AssetAttributes } from "../utils/types/attributeTypes";
 import { BaseService } from "./BaseService";
 import { IService } from "./IService";
@@ -15,6 +15,7 @@ class AssetService
 {
   constructor() {
     super(Asset);
+    init();
   }
 
   public async create(data: AssetAttributes): Promise<boolean> {

--- a/api/src/services/LocationService.ts
+++ b/api/src/services/LocationService.ts
@@ -11,7 +11,7 @@ interface ILocationService extends IService<Location> {
 export default class LocationService extends BaseService<Location> implements ILocationService {
   constructor() {
     super(Location);
-	init();
+    init();
   }
 
   public async create(data: LocationAttributes): Promise<boolean> {

--- a/api/src/services/LocationService.ts
+++ b/api/src/services/LocationService.ts
@@ -1,42 +1,43 @@
-import Location from "../database/models/location.model";
+import Location, { init } from "../database/models/location.model";
 import { LocationAttributes } from "../utils/types/attributeTypes";
 import { BaseService, IService } from "./BaseService";
 
 interface ILocationService extends IService<Location> {
-    create(data: LocationAttributes): Promise<boolean>;
-    update(locationId: number, data: LocationAttributes): Promise<boolean>;
-    delete(locationId: number): Promise<boolean>;
+  create(data: LocationAttributes): Promise<boolean>;
+  update(locationId: number, data: LocationAttributes): Promise<boolean>;
+  delete(locationId: number): Promise<boolean>;
 }
 
 export default class LocationService extends BaseService<Location> implements ILocationService {
-    constructor() {
-        super(Location);
+  constructor() {
+    super(Location);
+	init();
+  }
+
+  public async create(data: LocationAttributes): Promise<boolean> {
+    const isCreated = await Location.create(data);
+
+    if (isCreated.id <= 0) {
+      return false;
     }
+    return true;
+  }
 
-    public async create(data: LocationAttributes): Promise<boolean> {
-        const isCreated = await Location.create(data);
+  public async update(locationId: number, data: LocationAttributes): Promise<boolean> {
+    const isUpdated = await Location.update(data, { where: { id: locationId } });
 
-        if (isCreated.id <= 0) {
-            return false;
-        }
-        return true;
+    if (isUpdated[0] <= 0) {
+      return false;
     }
+    return true;
+  }
 
-    public async update(locationId: number, data: LocationAttributes): Promise<boolean> {
-        const isUpdated = await Location.update(data, { where: { id: locationId } });
+  public async delete(locationId: number): Promise<boolean> {
+    const isDeleted = await Location.destroy({ where: { id: locationId } });
 
-        if (isUpdated[0] <= 0) {
-            return false;
-        }
-        return true;
+    if (isDeleted <= 0) {
+      return false;
     }
-
-    public async delete(locationId: number): Promise<boolean> {
-        const isDeleted = await Location.destroy({ where: { id: locationId } });
-
-        if (isDeleted <= 0) {
-            return false;
-        }
-        return true;
-    }
+    return true;
+  }
 }

--- a/api/src/tests/unit/controllers/AssetController.test.ts
+++ b/api/src/tests/unit/controllers/AssetController.test.ts
@@ -83,7 +83,7 @@ describe('getAssetById', () => {
   afterEach(() => {
     jest.resetAllMocks();
     findByIdMock.mockReset();
-	resetMockLogger(logger);
+    resetMockLogger(logger);
   });
 
   it('Calls the next middleware with a BadRequestError when the params is missing id', async () => {
@@ -160,7 +160,7 @@ describe('createAsset', () => {
   afterEach(() => {
     jest.resetAllMocks();
     createMock.mockReset();
-	resetMockLogger(logger);
+    resetMockLogger(logger);
   });
 
   it('Calls the next middleware with a BadRequestError when the request body does not match the asset schema', async () => {
@@ -228,7 +228,7 @@ describe('updateAsset', () => {
     jest.resetAllMocks();
     findByIdMock.mockReset();
     updateMock.mockReset();
-	resetMockLogger(logger);
+    resetMockLogger(logger);
   });
 
   it('Calls the next middleware with a BadRequestError if the params.id is not present', async () => {
@@ -341,7 +341,7 @@ describe('deleteAsset', () => {
   afterEach(() => {
     jest.resetAllMocks();
     deleteMock.mockReset();
-	resetMockLogger(logger);
+    resetMockLogger(logger);
   });
 
   it('Calls the next middleware with a BadRequestError when the request is missing the id parameter', async () => {


### PR DESCRIPTION
- Refactored `databaseClient.ts` such that the connections are created by functions, instead of when imported.
  - Uses global scope variables for caching of created connections.
  - Changed missing database details from a `console.error` to throwing an `InternalServerError`.
- Updated logger being provided to `sequelize` and `umzug`, from `console` to `Logger`.
- Moved `Model.init` calls to within an `init` function, allowing it to be mocked.
  - Unit tests no longer needlessly try and connect to the database.
- Changed indentation spacing on some files to make more consistent with 2 spaces.