### PR TITLE
Validation reviving

### DIFF
--- a/api/src/tests/helpers/testData.ts
+++ b/api/src/tests/helpers/testData.ts
@@ -6,8 +6,6 @@ export const testAsset: AssetAttributes = {
   name: "testAsset",
   serialNumber: "testSerialNumber",
   modelNumber: "testModelNumber",
-  //purchaseDate: new Date(),
-  //purchaseCost: 234,
   nextAuditDate: new Date(),
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/api/src/tests/unit/controllers/AssetController.test.ts
+++ b/api/src/tests/unit/controllers/AssetController.test.ts
@@ -83,7 +83,7 @@ describe('getAssetById', () => {
   afterEach(() => {
     jest.resetAllMocks();
     findByIdMock.mockReset();
-	resetMockLogger(logger);
+    resetMockLogger(logger);
   });
 
   it('Calls the next middleware with a BadRequestError when the params is missing id', async () => {
@@ -160,7 +160,7 @@ describe('createAsset', () => {
   afterEach(() => {
     jest.resetAllMocks();
     createMock.mockReset();
-	resetMockLogger(logger);
+    resetMockLogger(logger);
   });
 
   it('Calls the next middleware with a BadRequestError when the request body does not match the asset schema', async () => {
@@ -187,7 +187,7 @@ describe('createAsset', () => {
     // Then
     expect(next).toHaveBeenCalledWith(ErrorController.InternalServerError("Unable to create new asset"));
     expectNonFinal(response);
-    expect(createMock).toHaveBeenCalledWith(request.body);
+    expect(createMock).toHaveBeenCalledWith(testAsset);
   });
 
   it('Sends a 204 response when the asset is successfully created', async () => {
@@ -228,7 +228,7 @@ describe('updateAsset', () => {
     jest.resetAllMocks();
     findByIdMock.mockReset();
     updateMock.mockReset();
-	resetMockLogger(logger);
+    resetMockLogger(logger);
   });
 
   it('Calls the next middleware with a BadRequestError if the params.id is not present', async () => {
@@ -302,7 +302,7 @@ describe('updateAsset', () => {
     expect(next).toHaveBeenCalledWith(ErrorController.InternalServerError("Unable to update selected asset"));
     expectNonFinal(response);
     expect(findByIdMock).toHaveBeenCalledWith(3);
-    expect(updateMock).toHaveBeenCalledWith(3, request.body);
+    expect(updateMock).toHaveBeenCalledWith(3, testAsset);
   });
 
   it('Sets a 204 status when updating an asset is successful', async () => {
@@ -320,7 +320,7 @@ describe('updateAsset', () => {
     expect(response.end).toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();
     expect(findByIdMock).toHaveBeenCalledWith(4);
-    expect(updateMock).toHaveBeenCalledWith(4, request.body);
+    expect(updateMock).toHaveBeenCalledWith(4, testAsset);
   });
 });
 
@@ -341,7 +341,7 @@ describe('deleteAsset', () => {
   afterEach(() => {
     jest.resetAllMocks();
     deleteMock.mockReset();
-	resetMockLogger(logger);
+    resetMockLogger(logger);
   });
 
   it('Calls the next middleware with a BadRequestError when the request is missing the id parameter', async () => {

--- a/api/src/utils/Validator.ts
+++ b/api/src/utils/Validator.ts
@@ -5,7 +5,7 @@ import * as schema_settings from "./schemas/schema_settings.json";
 import * as schema_user from "./schemas/schema_user.json";
 import { Request } from "express";
 import ErrorController from "../controllers/ErrorController";
-import { AssetAttributes, JsonString, LocationAttributes, UserAttributes } from "./types/attributeTypes";
+import { AssetAttributes, JsonNetworkType, LocationAttributes, UserAttributes } from "./types/attributeTypes";
 import { UserLogin } from "./types/authenticationTypes";
 import Logger from "./Logger";
 
@@ -28,9 +28,9 @@ export const getId = (request: Request): number => {
   return result;
 };
 
-const isAsset = (data: unknown): data is JsonString<AssetAttributes> => ajv.validate("asset", data);
-const isUser = (data: unknown): data is JsonString<UserAttributes> => ajv.validate("user", data);
-const isLocation = (data: unknown): data is JsonString<LocationAttributes> => ajv.validate("location", data);
+const isAsset = (data: unknown): data is JsonNetworkType<AssetAttributes> => ajv.validate("asset", data);
+const isUser = (data: unknown): data is JsonNetworkType<UserAttributes> => ajv.validate("user", data);
+const isLocation = (data: unknown): data is JsonNetworkType<LocationAttributes> => ajv.validate("location", data);
 
 export const validateAsset = (data: unknown): AssetAttributes => {
   if (!isAsset(data)) {
@@ -70,7 +70,7 @@ export const validateUserLogin = (data: unknown): UserLogin => {
   return { username, password };
 };
 
-const reviveAsset = (data: JsonString<AssetAttributes>): AssetAttributes => {
+const reviveAsset = (data: JsonNetworkType<AssetAttributes>): AssetAttributes => {
   const reviver = <T>(key: string, value: T): T | Date => {
     const dates = ["nextAuditDate", "createdAt", "updatedAt"];
     if (dates.includes(key) && typeof value === "string") return new Date(value);
@@ -79,7 +79,7 @@ const reviveAsset = (data: JsonString<AssetAttributes>): AssetAttributes => {
   return JSON.parse(JSON.stringify(data), reviver);
 };
 
-const reviveUser = (data: JsonString<UserAttributes>): UserAttributes => {
+const reviveUser = (data: JsonNetworkType<UserAttributes>): UserAttributes => {
   const reviver = <T>(key: string, value: T): T | Date => {
     const dates = ["createdAt", "updatedAt"];
     if (dates.includes(key) && typeof value === "string") return new Date(value);
@@ -88,7 +88,7 @@ const reviveUser = (data: JsonString<UserAttributes>): UserAttributes => {
   return JSON.parse(JSON.stringify(data), reviver);
 };
 
-const reviveLocation = (data: JsonString<LocationAttributes>): LocationAttributes => {
+const reviveLocation = (data: JsonNetworkType<LocationAttributes>): LocationAttributes => {
   const reviver = <T>(key: string, value: T): T | Date => {
     const dates = ["createdAt", "updatedAt"];
     if (dates.includes(key) && typeof value === "string") return new Date(value);

--- a/api/src/utils/Validator.ts
+++ b/api/src/utils/Validator.ts
@@ -47,7 +47,9 @@ export const validateUser = (data: unknown): UserAttributes => {
     Logger.error(ajv.errors);
     throw ErrorController.BadRequestError("Invalid Request");
   }
-  return data;
+  // Convert date fields from string into Date object
+  const result: UserAttributes = JSON.parse(JSON.stringify(data), reviveUser);
+  return result;
 };
 
 export const validateLocation = (data: unknown): LocationAttributes => {
@@ -74,6 +76,12 @@ export const validateUserLogin = (data: unknown): UserLogin => {
 
 const reviveAsset = <T>(key: string, value: T): T | Date => {
   const dates = ["nextAuditDate", "createdAt", "updatedAt"];
+  if (dates.includes(key) && typeof value === "string") return new Date(value);
+  return value;
+};
+
+const reviveUser = <T>(key: string, value: T): T | Date => {
+  const dates = ["createdAt", "updatedAt"];
   if (dates.includes(key) && typeof value === "string") return new Date(value);
   return value;
 };

--- a/api/src/utils/types/attributeTypes.ts
+++ b/api/src/utils/types/attributeTypes.ts
@@ -55,11 +55,11 @@ export interface UserLoginAttributes {
     password: string;
 }
 
-export type JsonString<T> =
+export type JsonNetworkType<T> =
   T extends Date ? string :
   T extends number ? T :
   T extends boolean ? T :
   T extends string ? T :
   T extends JSON ? T :
-  T extends object ? { [K in keyof T]?: JsonString<T[K]>} :
+  T extends object ? { [K in keyof T]?: JsonNetworkType<T[K]>} :
   never;

--- a/api/src/utils/types/attributeTypes.ts
+++ b/api/src/utils/types/attributeTypes.ts
@@ -55,3 +55,11 @@ export interface UserLoginAttributes {
     password: string;
 }
 
+export type JsonString<T> =
+  T extends Date ? string :
+  T extends number ? T :
+  T extends boolean ? T :
+  T extends string ? T :
+  T extends JSON ? T :
+  T extends object ? { [K in keyof T]?: JsonString<T[K]>} :
+  never;

--- a/api/src/utils/types/attributeTypes.ts
+++ b/api/src/utils/types/attributeTypes.ts
@@ -56,10 +56,14 @@ export interface UserLoginAttributes {
 }
 
 export type JsonNetworkType<T> =
+  // Types with manual reviving
   T extends Date ? string :
+  // Carry these through
   T extends number ? T :
   T extends boolean ? T :
   T extends string ? T :
   T extends JSON ? T :
   T extends object ? { [K in keyof T]?: JsonNetworkType<T[K]>} :
-  never;
+  T extends Array<infer E> ? Array<JsonNetworkType<E>> :
+  // Unknown case
+  T;

--- a/api/src/utils/types/attributeTypes.ts
+++ b/api/src/utils/types/attributeTypes.ts
@@ -4,8 +4,6 @@ export interface AssetAttributes {
     name: string;
     serialNumber?: string;
     modelNumber?: string;
-    purchaseDate?: Date;
-    purchaseCost?: Number;
     nextAuditDate?: Date;
     createdAt?: Date;
     updatedAt?: Date;


### PR DESCRIPTION
- Add data reviving at validation stage.
- Convert values from `string` to `Date` as required.
  - Avoids date-time `string` values being attempted to be inserted to DB as a `DATE` type, potentially causing issues.
- Add type to dictate whether an object needs to be revived.
- Updated unit tests for `AssetController` that were incorrectly expecting the database to have been called with `string`, so restored to expecting `testAsset` as opposed to `req.body`.
- Removed optional fields from `AssetAttributes` `interface` that were not used anywhere.
- Added error logging when a request fails `ajv` validation.