### PR TITLE
Sequelize seeding

### DIFF
--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -81,4 +81,11 @@ export const startup = async () => {
   await seeder.up();
 };
 
-export type Migration = typeof Umzug.prototype._types.migration;
+export const shutdown = async () => {
+  const migrator = getMigrator();
+  const seeder = getSeeder();
+  await seeder.down();
+  await migrator.down();
+};
+
+export type Migration = Umzug<QueryInterface>["_types"]["migration"];

--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -74,6 +74,7 @@ export const getSeeder = (): Umzug<QueryInterface> => {
   return seeder;
 };
 
+// TODO: Only use seeder when testing, in both startup and shutdown
 export const startup = async () => {
   const migrator = getMigrator();
   const seeder = getSeeder();

--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -3,6 +3,7 @@ import { QueryInterface, Sequelize } from "sequelize";
 import { SequelizeStorage, Umzug } from "umzug";
 import ErrorController from "../../controllers/ErrorController";
 import Logger from "../../utils/Logger";
+import { isDevelopment } from "../../utils";
 
 interface DatabaseClient {
   sequelize: Sequelize;
@@ -74,11 +75,10 @@ export const getSeeder = (): Umzug<QueryInterface> => {
   return seeder;
 };
 
-// TODO: Only use seeder when testing, in both startup and shutdown
 export const startup = async () => {
   const migrator = getMigrator();
   await migrator.up();
-  if (process.env.NODE_ENV === "development") {
+  if (isDevelopment()) {
     const seeder = getSeeder();
     await seeder.up();
   }

--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -13,6 +13,7 @@ let connectionUrl: string | undefined;
 let sequelize: Sequelize | undefined;
 let db: DatabaseClient | undefined;
 let migrator: Umzug<QueryInterface> | undefined;
+let seeder: Umzug<QueryInterface> | undefined;
 
 const getConnectionUrl = (): string => {
   if (connectionUrl !== undefined) return connectionUrl;
@@ -57,6 +58,27 @@ export const getMigrator = (): Umzug<QueryInterface> => {
     logger: Logger,
   });
   return migrator;
+};
+
+export const getSeeder = (): Umzug<QueryInterface> => {
+  if (seeder !== undefined) return seeder;
+  const sequelize = getSequelizeConnection();
+  seeder = new Umzug({
+    migrations: {
+      glob: "src/database/seeding/*.seeding.ts",
+    },
+    context: sequelize.getQueryInterface(),
+    storage: new SequelizeStorage({ sequelize }),
+    logger: Logger,
+  });
+  return seeder;
+};
+
+export const startup = async () => {
+  const migrator = getMigrator();
+  const seeder = getSeeder();
+  await migrator.up();
+  await seeder.up();
 };
 
 export type Migration = typeof Umzug.prototype._types.migration;

--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -77,16 +77,11 @@ export const getSeeder = (): Umzug<QueryInterface> => {
 // TODO: Only use seeder when testing, in both startup and shutdown
 export const startup = async () => {
   const migrator = getMigrator();
-  const seeder = getSeeder();
   await migrator.up();
-  await seeder.up();
-};
-
-export const shutdown = async () => {
-  const migrator = getMigrator();
-  const seeder = getSeeder();
-  await seeder.down();
-  await migrator.down();
+  if (process.env.NODE_ENV === "development") {
+    const seeder = getSeeder();
+    await seeder.up();
+  }
 };
 
 export type Migration = Umzug<QueryInterface>["_types"]["migration"];

--- a/api/src/database/migrations/initial.migration.ts
+++ b/api/src/database/migrations/initial.migration.ts
@@ -2,7 +2,7 @@ import type { Migration } from "../config/databaseClient";
 import { DataTypes } from "sequelize";
 
 export const up: Migration = async ({ context: queryInterface }) => {
-  await queryInterface.createTable("assets", {
+  const assets = queryInterface.createTable("assets", {
     id: {
       type: DataTypes.INTEGER,
       primaryKey: true,
@@ -39,7 +39,7 @@ export const up: Migration = async ({ context: queryInterface }) => {
     },
   });
 
-  await queryInterface.createTable("locations", {
+  const locations = queryInterface.createTable("locations", {
     id: {
       type: DataTypes.INTEGER,
       primaryKey: true,
@@ -68,7 +68,7 @@ export const up: Migration = async ({ context: queryInterface }) => {
     },
   });
 
-  await queryInterface.createTable("settings", {
+  const settings = queryInterface.createTable("settings", {
     id: {
       type: DataTypes.INTEGER,
       autoIncrement: true,
@@ -84,7 +84,7 @@ export const up: Migration = async ({ context: queryInterface }) => {
     },
   });
 
-  await queryInterface.createTable("users", {
+  const users = queryInterface.createTable("users", {
     id: {
       type: DataTypes.INTEGER,
       autoIncrement: true,
@@ -127,11 +127,16 @@ export const up: Migration = async ({ context: queryInterface }) => {
       allowNull: true,
     },
   });
+  await Promise.all([
+    assets, locations, settings, users,
+  ]);
 };
 
 export const down: Migration = async ({ context: queryInterface }) => {
-  await queryInterface.dropTable("assets");
-  await queryInterface.dropTable("locations");
-  await queryInterface.dropTable("settings");
-  await queryInterface.dropTable("users");
+  await Promise.all([
+    queryInterface.dropTable("assets"),
+    queryInterface.dropTable("locations"),
+    queryInterface.dropTable("settings"),
+    queryInterface.dropTable("users"),
+  ]);
 };

--- a/api/src/database/migrations/initial.migration.ts
+++ b/api/src/database/migrations/initial.migration.ts
@@ -114,7 +114,7 @@ export const up: Migration = async ({ context: queryInterface }) => {
       type: DataTypes.BOOLEAN,
       allowNull: false,
     },
-    scope: {
+    scopes: {
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: false,
     },

--- a/api/src/database/migrations/scopes.migration.ts
+++ b/api/src/database/migrations/scopes.migration.ts
@@ -1,0 +1,9 @@
+import type { Migration } from "../config/databaseClient";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.renameColumn("users", "scopes", "scope");
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.renameColumn("users", "scope", "scopes");
+};

--- a/api/src/database/seeding/database.seeding.ts
+++ b/api/src/database/seeding/database.seeding.ts
@@ -1,0 +1,4 @@
+import type { Migration } from "../config/databaseClient";
+
+export const up: Migration = async () => {};
+export const down: Migration = async () => {};

--- a/api/src/database/seeding/database.seeding.ts
+++ b/api/src/database/seeding/database.seeding.ts
@@ -1,4 +1,0 @@
-import type { Migration } from "../config/databaseClient";
-
-export const up: Migration = async () => {};
-export const down: Migration = async () => {};

--- a/api/src/database/seeding/users.seeding.ts
+++ b/api/src/database/seeding/users.seeding.ts
@@ -1,4 +1,4 @@
-import { UserAttributes } from "../../utils/types/attributeTypes";
+import { Scope, UserAttributes } from "../../utils/types/attributeTypes";
 import AuthenticationService from "../../services/AuthenticationService";
 import type { Migration } from "../config/databaseClient";
 import User from "../models/user.model";
@@ -10,9 +10,9 @@ export const up: Migration = async () => {
     lastName: "TEST_ADMIN",
     username: "TEST_ADMIN",
     password: await authService.hashPassword("TEST_ADMIN_PASSWORD"),
-    email: "",
+    email: "email",
     isActive: true,
-    scope: [],
+    scope: [Scope.USER_CREATE],
   };
   const user: UserAttributes = {
     firstName: "TEST_USER",
@@ -21,11 +21,11 @@ export const up: Migration = async () => {
     password: await authService.hashPassword("TEST_USER_PASSWORD"),
     email: "",
     isActive: true,
-    scope: [],
+    scope: [Scope.READ],
   };
   await Promise.all([
-    User.upsert(userAdmin),
-    User.upsert(user),
+    User.create(userAdmin),
+    User.create(user),
   ]);
 };
 

--- a/api/src/database/seeding/users.seeding.ts
+++ b/api/src/database/seeding/users.seeding.ts
@@ -1,0 +1,37 @@
+import { UserAttributes } from "../../utils/types/attributeTypes";
+import AuthenticationService from "../../services/AuthenticationService";
+import type { Migration } from "../config/databaseClient";
+import User from "../models/user.model";
+
+export const up: Migration = async () => {
+  const authService = new AuthenticationService();
+  const userAdmin: UserAttributes = {
+    firstName: "TEST_ADMIN",
+    lastName: "TEST_ADMIN",
+    username: "TEST_ADMIN",
+    password: await authService.hashPassword("TEST_ADMIN_PASSWORD"),
+    email: "",
+    isActive: true,
+    scope: [],
+  };
+  const user: UserAttributes = {
+    firstName: "TEST_USER",
+    lastName: "TEST_USER",
+    username: "TEST_USER",
+    password: await authService.hashPassword("TEST_USER_PASSWORD"),
+    email: "",
+    isActive: true,
+    scope: [],
+  };
+  await Promise.all([
+    User.upsert(userAdmin),
+    User.upsert(user),
+  ]);
+};
+
+export const down: Migration = async () => {
+  await Promise.all([
+    User.destroy({ where: { username: "TEST_ADMIN" } }),
+    User.destroy({ where: { username: "TEST_USER" } }),
+  ]);
+};

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import express, { Express } from "express";
-import { getMigrator } from "./database/config/databaseClient";
+import { startup as databaseStartup } from "./database/config/databaseClient";
 import { getRedisClient } from "./database/config/redisClient";
 import cors from "cors";
 import helmet from "helmet";
@@ -30,17 +30,17 @@ app.use("/auth", authRouter);
 app.use(errorHandler);
 
 const startupConfiguration = async () => {
-  const migrator = getMigrator();
   const redisClient = getRedisClient();
   await Promise.all([
-    migrator.up(),
+    databaseStartup(),
     redisClient.connect(),
   ]);
 };
 
-app.listen(port, () => {
-  console.log(`Server is running on port: ${port}`);
-  startupConfiguration();
+app.listen(port, async () => {
+  console.log(`Server is starting on port: ${port}`);
+  await startupConfiguration();
+  console.log(`Server has started on port: ${port}`);
 });
 
 export default app;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import express, { Express } from "express";
-import { startup as databaseStartup, shutdown as databaseShutdown } from "./database/config/databaseClient";
+import { startup as databaseStartup, getSeeder } from "./database/config/databaseClient";
 import { getRedisClient } from "./database/config/redisClient";
 import cors from "cors";
 import helmet from "helmet";
@@ -46,7 +46,10 @@ const server = app.listen(port, async () => {
 // TODO: Attach as callback to listener. Exported only to allow to be unused
 export const shutdown = async () => {
   console.log("Shutting down server...");
-  await databaseShutdown();
+  if (process.env.NODE_ENV === "development") {
+    const seeder = getSeeder();
+    await seeder.down();
+  }
   server.close(() => {
     console.log("Server has shutdown");
   });

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import express, { Express } from "express";
-import { startup as databaseStartup } from "./database/config/databaseClient";
+import { startup as databaseStartup, shutdown as databaseShutdown } from "./database/config/databaseClient";
 import { getRedisClient } from "./database/config/redisClient";
 import cors from "cors";
 import helmet from "helmet";
@@ -37,10 +37,19 @@ const startupConfiguration = async () => {
   ]);
 };
 
-app.listen(port, async () => {
+const server = app.listen(port, async () => {
   console.log(`Server is starting on port: ${port}`);
   await startupConfiguration();
   console.log(`Server has started on port: ${port}`);
 });
+
+// TODO: Attach as callback to listener. Exported only to allow to be unused
+export const shutdown = async () => {
+  console.log("Shutting down server...");
+  await databaseShutdown();
+  server.close(() => {
+    console.log("Server has shutdown");
+  });
+};
 
 export default app;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,7 @@ import authRouter from "./routes/AuthRouter";
 import { rateLimiterMiddleware } from "./middlewares/requestRateLimiter";
 import { errorHandler } from "./middlewares/errorHandler";
 import { httpRequestLogger } from "./middlewares/httpRequestLogger";
+import { isDevelopment } from "./utils";
 
 const app: Express = express();
 const port = process.env.API_PORT;
@@ -43,16 +44,15 @@ const server = app.listen(port, async () => {
   console.log(`Server has started on port: ${port}`);
 });
 
-// TODO: Attach as callback to listener. Exported only to allow to be unused
-export const shutdown = async () => {
+process.on("SIGINT", async () => {
   console.log("Shutting down server...");
-  if (process.env.NODE_ENV === "development") {
+  if (isDevelopment()) {
     const seeder = getSeeder();
     await seeder.down();
   }
   server.close(() => {
     console.log("Server has shutdown");
   });
-};
+});
 
 export default app;

--- a/api/src/utils/Logger.ts
+++ b/api/src/utils/Logger.ts
@@ -1,9 +1,8 @@
 import winston from "winston";
-
-const { NODE_ENV } = process.env;
+import { isDevelopment } from "./index";
 
 const Logger = winston.createLogger({
-  level: NODE_ENV === "development" ? "debug" : "warn",
+  level: isDevelopment() ? "debug" : "warn",
   format: winston.format.combine(
     winston.format.timestamp(),
     winston.format.json(),

--- a/api/src/utils/index.ts
+++ b/api/src/utils/index.ts
@@ -1,0 +1,1 @@
+export const isDevelopment = (): boolean => process.env.NODE_ENV === "development";


### PR DESCRIPTION
## API
- Add database seeding using `sequelize` and `umzug` since they are already being used for migrations.
  - Only runs within `development` environments, to avoid having default admin users within production.
  - Stores seeding files within `/database/seeding` directory.
  - Reverts the seeding with `seeder.down` upon closing the application.
- Added missing migration from when renamed column name from `scopes` to `scope` in the database to match the `UserAttributes` type which is matching the OAuth specification.
  - Reverted `initial.migration.ts` to create the table with field `scopes` since that was the original schema, and is required to work with the new migration file in the pipeline.
- Modified `initial.migration.ts` to pararellise the promises, using `Promise.all`.

Closes #12 