### PR TITLE
Git Hooks

### DIFF
--- a/.github/workflows/onPullRequest.yml
+++ b/.github/workflows/onPullRequest.yml
@@ -85,7 +85,6 @@ jobs:
         run: npm run start & sleep 10
         working-directory: api
         env:
-          EXPRESS_SECRET_KEY: pipeline
           API_PORT: 7071
           API_DATABASE_NAME: pipeline
           API_DATABASE_USERNAME: pipeline
@@ -99,7 +98,6 @@ jobs:
         run: npm run test:integration
         working-directory: api
         env:
-          EXPRESS_SECRET_KEY: pipeline
           API_PORT: 7071
 
   Web-E2E:
@@ -150,7 +148,6 @@ jobs:
         run: npm run start & sleep 10
         working-directory: api
         env:
-          EXPRESS_SECRET_KEY: pipeline
           API_PORT: 3000
           API_DATABASE_NAME: pipeline
           API_DATABASE_USERNAME: pipeline

--- a/README.md
+++ b/README.md
@@ -29,15 +29,13 @@ API_SEED_DATABASE="true" # Only to be set if in a trusted environment. Has secur
 ```
 
 ## API Integration Tests
-The integration tests require to be using the same token signing key as the API is using to validate.
-This can be achieved by setting the environment variable ```EXPRESS_SECRET_KEY``` to the same non-falsy value on both.
-e.g.
 ```sh
-EXPRESS_SECRET_KEY="trace" npm start
-EXPRESS_SECRET_KEY="trace" npm run test:integration
+API_SEED_DATABASE=true npm start
+npm run test:integration
 ```
 
 ## Git Hooks
+In order to configure the running of existing `pre-commit` and `pre-push` hooks, run within the Git Repository
 ```sh
 git config core.hooksPath hooks
 ```

--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ e.g.
 EXPRESS_SECRET_KEY="trace" npm start
 EXPRESS_SECRET_KEY="trace" npm run test:integration
 ```
+
+## Git Hooks
+```sh
+git config core.hooksPath hooks
+```

--- a/api/src/database/config/databaseClient.ts
+++ b/api/src/database/config/databaseClient.ts
@@ -84,6 +84,7 @@ export const startup = async () => {
     Logger.warn("Database seeding is enabled. This results in public admin credentials.");
     Logger.info("Seeding database");
     const seeder = getSeeder();
+    await seeder.down();
     await seeder.up();
     Logger.info("Seeded database");
   }

--- a/api/src/database/seeding/users.seeding.ts
+++ b/api/src/database/seeding/users.seeding.ts
@@ -9,7 +9,7 @@ export const up: Migration = async () => {
     firstName: name,
     lastName: name,
     username: name,
-    password: await authService.hashPassword(name),
+    password: await authService.hashPassword(`${name}_PASSWORD`),
     email: "",
     isActive: true,
     scope: scopes,

--- a/api/src/database/seeding/users.seeding.ts
+++ b/api/src/database/seeding/users.seeding.ts
@@ -5,28 +5,21 @@ import User, { init } from "../models/user.model";
 
 export const up: Migration = async () => {
   const authService = new AuthenticationService();
-  const userAdmin: UserCreationAttributes = {
-    firstName: "TEST_ADMIN",
-    lastName: "TEST_ADMIN",
-    username: "TEST_ADMIN",
-    password: await authService.hashPassword("TEST_ADMIN_PASSWORD"),
-    email: "email",
-    isActive: true,
-    scope: [Scope.USER_CREATE],
-  };
-  const user: UserCreationAttributes = {
-    firstName: "TEST_USER",
-    lastName: "TEST_USER",
-    username: "TEST_USER",
-    password: await authService.hashPassword("TEST_USER_PASSWORD"),
+  const createUser = async (name: string, scopes: Scope[]): Promise<UserCreationAttributes> => ({
+    firstName: name,
+    lastName: name,
+    username: name,
+    password: await authService.hashPassword(name),
     email: "",
     isActive: true,
-    scope: [Scope.READ],
-  };
+    scope: scopes,
+  });
   init();
   await Promise.all([
-    User.create(userAdmin),
-    User.create(user),
+    createUser("TEST_ADMIN", [Scope.USER_CREATE]).then((user) => User.create(user)),
+    createUser("TEST_USER", [Scope.READ]).then((user) => User.create(user)),
+    createUser("TEST_USER_CREATE", [Scope.READ, Scope.ASSET_CREATE]).then((user) => User.create(user)),
+    createUser("TEST_USER_NONE", []).then((user) => User.create(user)),
   ]);
 };
 
@@ -35,5 +28,7 @@ export const down: Migration = async () => {
   await Promise.all([
     User.destroy({ where: { username: "TEST_ADMIN" } }),
     User.destroy({ where: { username: "TEST_USER" } }),
+    User.destroy({ where: { username: "TEST_USER_CREATE" } }),
+    User.destroy({ where: { username: "TEST_USER_NONE" } }),
   ]);
 };

--- a/api/src/database/seeding/users.seeding.ts
+++ b/api/src/database/seeding/users.seeding.ts
@@ -5,7 +5,7 @@ import User, { init } from "../models/user.model";
 
 export const up: Migration = async () => {
   const authService = new AuthenticationService();
-  const createUser = async (name: string, scopes: Scope[]): Promise<UserCreationAttributes> => ({
+  const generateUser = async (name: string, scopes: Scope[]): Promise<UserCreationAttributes> => ({
     firstName: name,
     lastName: name,
     username: name,
@@ -14,12 +14,16 @@ export const up: Migration = async () => {
     isActive: true,
     scope: scopes,
   });
+  const createUser = async (name: string, scopes: Scope[]): Promise<void> => {
+    const user = await generateUser(name, scopes);
+    await User.create(user);
+  };
   init();
   await Promise.all([
-    createUser("TEST_ADMIN", [Scope.USER_CREATE]).then((user) => User.create(user)),
-    createUser("TEST_USER", [Scope.READ]).then((user) => User.create(user)),
-    createUser("TEST_USER_CREATE", [Scope.READ, Scope.ASSET_CREATE]).then((user) => User.create(user)),
-    createUser("TEST_USER_NONE", []).then((user) => User.create(user)),
+    createUser("TEST_ADMIN", [Scope.USER_CREATE]),
+    createUser("TEST_USER", [Scope.READ]),
+    createUser("TEST_USER_CREATE", [Scope.READ, Scope.ASSET_CREATE]),
+    createUser("TEST_USER_NONE", []),
   ]);
 };
 

--- a/api/src/tests/helpers/accounts.ts
+++ b/api/src/tests/helpers/accounts.ts
@@ -1,0 +1,24 @@
+const { API_PORT } = process.env;
+const API_URL = `http://localhost:${API_PORT}`;
+
+export interface Tokens {
+  accessToken: string;
+  idToken: string;
+  refreshToken: string;
+}
+
+export const signIn = async (username: string, password: string): Promise<Tokens> => {
+  const options = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      username,
+      password,
+    }),
+  };
+  const res = await fetch(`${API_URL}/auth/login`, options);
+  const data: Tokens = await res.json();
+  return data;
+}

--- a/api/src/tests/integration/asset.test.ts
+++ b/api/src/tests/integration/asset.test.ts
@@ -1,5 +1,4 @@
-import AuthService from "../../services/AuthenticationService";
-import { Scope } from "../../utils/types/attributeTypes";
+import { signIn } from "../helpers/accounts";
 import { testCreationAsset } from "../helpers/testData";
 const { API_PORT } = process.env;
 
@@ -11,15 +10,10 @@ const headers = {
 };
 
 describe("POST /assets", () => {
-  let authService: AuthService;
-
-  beforeEach(() => {
-    authService = new AuthService();
-  });
-
   it('It creates an Asset', async () => {
     // Given
-    headers.authorization = `Bearer ${authService.generateAccessToken(["TRACE_READ" as Scope, "TRACE_ASSET_CREATE" as Scope], "TEST_USER")}`;
+    const { accessToken } = await signIn("TEST_USER_CREATE", "TEST_USER_CREATE_PASSWORD");
+    headers.authorization = `Bearer ${accessToken}`;
 
     // When
     const response = await fetch(`${API_URL}/assets`, {
@@ -53,7 +47,8 @@ describe("POST /assets", () => {
 
   it('Sets a 403 status when the user is unauthorised', async () => {
     // Given
-    headers.authorization = `Bearer ${authService.generateAccessToken([], "TEST_USER")}`;
+    const { accessToken } = await signIn("TEST_USER_NONE", "TEST_USER_NONE_PASSWORD");
+    headers.authorization = `Bearer ${accessToken}`;
 
     // When
     const response = await fetch(`${API_URL}/assets`, {

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,7 @@
+set -e
+
+npm run test:unit --prefix api
+npm run test --prefix web
+
+npm run lint --prefix api
+npm run lint --prefix web

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,10 @@
+set -e
+
+npm run test:unit --prefix api
+npm run test --prefix web
+
+npm run lint --prefix api
+npm run lint --prefix web
+
+EXPRESS_SECRET_KEY="trace" npm run test:integration --prefix api
+npm run e2e --prefix web

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -6,5 +6,5 @@ npm run test --prefix web
 npm run lint --prefix api
 npm run lint --prefix web
 
-EXPRESS_SECRET_KEY="trace" npm run test:integration --prefix api
+npm run test:integration --prefix api
 npm run e2e --prefix web

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",
-    "test": "vitest src",
+    "test": "vitest run src",
+    "test:watch": "vitest src",
     "test:coverage": "vitest run src --coverage",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",


### PR DESCRIPTION
- Added `pre-commit` and `pre-push` git hooks.
- Added 2 more test users to database seeding.
- Adapted Integration tests to use username and password credentials instead of generating a token.
  - Removed dependence upon `AuthService` and thus `process.env.EXPRESS_SECRET_KEY`
- Removed references to `EXPRESS_SECRET_KEY` when running integration tests, or running in the pipeline, since it is no longer required.
- Added documentation to cover setting up git hooks.
- Set database seeder to call `down`, so that it always calls `up` to reflect changes in the seeding scripts.