### PR TITLE
Asset Fetching

### DIFF
--- a/api/src/routes/DashboardRouter.ts
+++ b/api/src/routes/DashboardRouter.ts
@@ -15,6 +15,7 @@ router.route("/").get(
     authoriseRequest(req, res, next);
   },
   (req, res, next) => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     dashboardController.getDashboardStats(req, res, next);
   }
 );

--- a/api/src/services/DashboardService.ts
+++ b/api/src/services/DashboardService.ts
@@ -8,7 +8,7 @@ import {
 
 interface IDashboardService {
   getTotalInventoryCount(): Promise<TotalInventoryCount[]>;
-  getTotalInventoryStatus(): Promise<TotalInventoryStatuses[]>;
+  getTotalInventoryStatus(): Promise<TotalInventoryStatuses>;
   getRecentlyAddedInventory(): Promise<RecentlyAddedInventory>;
 }
 
@@ -22,14 +22,14 @@ class DashboardService implements IDashboardService {
     return [{ assets: assetTotalCount.count }];
   }
 
-  public async getTotalInventoryStatus(): Promise<TotalInventoryStatuses[]> {
+  public async getTotalInventoryStatus(): Promise<TotalInventoryStatuses> {
     const assetStatus = await Asset.findAll({
       attributes: [
         "status",
         [sequelize.fn("COUNT", sequelize.col("status")), "total"],
       ],
       group: "status",
-    }) as Array<unknown> as Array<TotalInventoryStatuses>;
+    }) as Array<unknown> as TotalInventoryStatuses;
     return assetStatus;
   }
 

--- a/api/src/services/DashboardService.ts
+++ b/api/src/services/DashboardService.ts
@@ -7,7 +7,7 @@ import {
 } from "../utils/types/attributeTypes";
 
 interface IDashboardService {
-  getTotalInventoryCount(): Promise<TotalInventoryCount[]>;
+  getTotalInventoryCount(): Promise<TotalInventoryCount>;
   getTotalInventoryStatus(): Promise<TotalInventoryStatuses>;
   getRecentlyAddedInventory(): Promise<RecentlyAddedInventory>;
 }
@@ -17,9 +17,9 @@ class DashboardService implements IDashboardService {
     init();
   }
 
-  public async getTotalInventoryCount(): Promise<TotalInventoryCount[]> {
+  public async getTotalInventoryCount(): Promise<TotalInventoryCount> {
     const assetTotalCount = await Asset.findAndCountAll();
-    return [{ assets: assetTotalCount.count }];
+    return { assets: assetTotalCount.count };
   }
 
   public async getTotalInventoryStatus(): Promise<TotalInventoryStatuses> {

--- a/api/src/services/DashboardService.ts
+++ b/api/src/services/DashboardService.ts
@@ -4,6 +4,7 @@ import {
   RecentlyAddedInventory,
   TotalInventoryCount,
   TotalInventoryStatuses,
+  Status,
 } from "../utils/types/attributeTypes";
 
 interface IDashboardService {
@@ -29,8 +30,21 @@ class DashboardService implements IDashboardService {
         [sequelize.fn("COUNT", sequelize.col("status")), "total"],
       ],
       group: "status",
-    }) as Array<unknown> as TotalInventoryStatuses;
-    return assetStatus;
+    }) as Array<unknown> as Array<{ status: Status; total: number}>;
+    const initial: TotalInventoryStatuses = {
+      [Status.IN_MAINTAINCE]: 0,
+      [Status.SERVICEABLE]: 0,
+      [Status.UNKNOWN]: 0,
+      [Status.UNSERVICEABLE]: 0,
+    };
+    return assetStatus.reduce(
+      (prev, current) => {
+        const { total } = JSON.parse(JSON.stringify(current)) as { total: string };
+        return {...prev, [current.status]: parseInt(total) };
+      },
+      initial,
+    );
+
   }
 
   public async getRecentlyAddedInventory(): Promise<RecentlyAddedInventory> {

--- a/api/src/utils/types/attributeTypes.ts
+++ b/api/src/utils/types/attributeTypes.ts
@@ -98,7 +98,7 @@ export type TotalInventoryCount = {
   assets: number;
 };
 
-export type TotalInventoryStatuses = Array<{ status: Status, total: number }>;
+export type TotalInventoryStatuses = Record<Status, number>;
 export type RecentlyAddedInventory = AssetStoredAttributes[];
 
 export type DashboardData = {

--- a/api/src/utils/types/attributeTypes.ts
+++ b/api/src/utils/types/attributeTypes.ts
@@ -102,7 +102,7 @@ export type TotalInventoryStatuses = Array<{ status: Status, total: number }>;
 export type RecentlyAddedInventory = AssetStoredAttributes[];
 
 export type DashboardData = {
-  totalInventoryCount: TotalInventoryCount[];
+  totalInventoryCount: TotalInventoryCount;
   totalInventoryStatuses: TotalInventoryStatuses;
   recentlyAddedInventory: RecentlyAddedInventory;
 };

--- a/api/src/utils/types/attributeTypes.ts
+++ b/api/src/utils/types/attributeTypes.ts
@@ -103,6 +103,6 @@ export type RecentlyAddedInventory = AssetStoredAttributes[];
 
 export type DashboardData = {
   totalInventoryCount: TotalInventoryCount[];
-  totalInventoryStatuses: TotalInventoryStatuses[];
+  totalInventoryStatuses: TotalInventoryStatuses;
   recentlyAddedInventory: RecentlyAddedInventory;
 };

--- a/api/src/utils/types/attributeTypes.ts
+++ b/api/src/utils/types/attributeTypes.ts
@@ -1,5 +1,4 @@
 import { UUID } from "crypto";
-import Asset from "../../database/models/asset.model";
 
 export interface AssetCreationAttributes {
   assetTag: string;
@@ -100,7 +99,7 @@ export type TotalInventoryCount = {
 };
 
 export type TotalInventoryStatuses = Array<{ status: Status, total: number }>;
-export type RecentlyAddedInventory = Asset[];
+export type RecentlyAddedInventory = AssetStoredAttributes[];
 
 export type DashboardData = {
   totalInventoryCount: TotalInventoryCount[];

--- a/web/src/components/ui/chartView/index.tsx
+++ b/web/src/components/ui/chartView/index.tsx
@@ -4,9 +4,9 @@ import { Doughnut } from "react-chartjs-2";
 import { Box } from "@mui/material";
 import type { TotalInventoryCount } from "../../../utils/types/attributes";
 
-type ChartViewProps = {
-  data: TotalInventoryCount[];
-};
+interface ChartViewProps {
+  data: TotalInventoryCount[] | undefined;
+}
 
 Chart.register(ArcElement, Tooltip, Legend);
 
@@ -20,7 +20,7 @@ const ChartView: React.FC<ChartViewProps> = ({ data }) => {
             datasets: [
               {
                 label: "Total Assets",
-                data: data.map((i) => i.assets),
+                data: data?.map((i) => i.assets),
                 backgroundColor: ["green", "blue"],
               },
             ],

--- a/web/src/components/ui/chartView/index.tsx
+++ b/web/src/components/ui/chartView/index.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { ArcElement, Chart, Legend, Tooltip } from "chart.js";
 import { Doughnut } from "react-chartjs-2";
-import { Box, Paper } from "@mui/material";
-import { TotalInventoryCount } from "../../../../../api/src/utils/types/attributeTypes";
+import { Box } from "@mui/material";
+import type { TotalInventoryCount } from "../../../utils/types/attributes";
 
 type ChartViewProps = {
   data: TotalInventoryCount[];

--- a/web/src/components/ui/chartView/index.tsx
+++ b/web/src/components/ui/chartView/index.tsx
@@ -5,7 +5,7 @@ import { Box } from "@mui/material";
 import type { TotalInventoryCount } from "../../../utils/types/attributes";
 
 interface ChartViewProps {
-  data: TotalInventoryCount[] | undefined;
+  data: TotalInventoryCount | undefined;
 }
 
 Chart.register(ArcElement, Tooltip, Legend);
@@ -20,7 +20,7 @@ const ChartView: React.FC<ChartViewProps> = ({ data }) => {
             datasets: [
               {
                 label: "Total Assets",
-                data: data?.map((i) => i.assets),
+                data: data ? [data.assets] : undefined,
                 backgroundColor: ["green", "blue"],
               },
             ],

--- a/web/src/components/ui/navItem/index.tsx
+++ b/web/src/components/ui/navItem/index.tsx
@@ -7,12 +7,12 @@ import {
 import React from "react";
 import { Link } from "react-router-dom";
 
-type NavItemProps = {
+interface NavItemProps {
   icon: React.ReactElement;
   name: string;
   link: string;
   onClickCallback?: () => void;
-};
+}
 
 const IconButton = styled(MuiIconButton)({
   display: "flex",

--- a/web/src/components/ui/statusItem/index.tsx
+++ b/web/src/components/ui/statusItem/index.tsx
@@ -6,10 +6,10 @@ import RemoveCircleIcon from "@mui/icons-material/RemoveCircle";
 import HelpIcon from "@mui/icons-material/Help";
 import { Status } from "../../../utils/types/attributes";
 
-type StatusItemProps = {
+interface StatusItemProps {
   statusTotal: number;
   statusType: Status;
-};
+}
 
 const StatusItem: React.FC<StatusItemProps> = ({ statusTotal, statusType }) => {
   return (

--- a/web/src/components/ui/statusItem/index.tsx
+++ b/web/src/components/ui/statusItem/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Icon, Typography } from "@mui/material";
+import { Box, Icon, Typography, Skeleton } from "@mui/material";
 import React from "react";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
@@ -7,7 +7,7 @@ import HelpIcon from "@mui/icons-material/Help";
 import { Status } from "../../../utils/types/attributes";
 
 interface StatusItemProps {
-  statusTotal: number;
+  statusTotal: number | undefined;
   statusType: Status;
 }
 
@@ -22,7 +22,7 @@ const StatusItem: React.FC<StatusItemProps> = ({ statusTotal, statusType }) => {
         }}
       >
         <Icon>{StatusIcon(statusType)}</Icon>
-        <Typography>{statusTotal}</Typography>
+        <Typography>{statusTotal ?? <Skeleton/>}</Typography>
         <Typography>{statusType}</Typography>
       </Box>
     </>

--- a/web/src/components/ui/statusItem/index.tsx
+++ b/web/src/components/ui/statusItem/index.tsx
@@ -4,7 +4,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import RemoveCircleIcon from "@mui/icons-material/RemoveCircle";
 import HelpIcon from "@mui/icons-material/Help";
-import { Status } from "../../../../../api/src/utils/types/attributeTypes";
+import { Status } from "../../../utils/types/attributes";
 
 type StatusItemProps = {
   statusTotal: number;

--- a/web/src/components/views/statusView.tsx
+++ b/web/src/components/views/statusView.tsx
@@ -6,7 +6,7 @@ import {
   TotalInventoryStatuses,
 } from "../../utils/types/attributes";
 
-type StatusViewProps = {
+interface StatusViewProps {
   data: TotalInventoryStatuses | undefined;
 };
 
@@ -22,7 +22,7 @@ const StatusView: React.FC<StatusViewProps> = ({ data }) => {
   return (
     <Box sx={{ display: "flex", flexDirection: "row" }}>
       <Typography>Inventory Status</Typography>
-	  {data?.map((item, index) => {
+      {data?.map((item, index) => {
         return (
           <Box id={index.toString()}>
             <StatusItem statusTotal={item.total} statusType={item.status} />

--- a/web/src/components/views/statusView.tsx
+++ b/web/src/components/views/statusView.tsx
@@ -4,7 +4,7 @@ import StatusItem from "../ui/statusItem";
 import {
   Status,
   TotalInventoryStatuses,
-} from "../../../../api/src/utils/types/attributeTypes";
+} from "../../utils/types/attributes";
 
 type StatusViewProps = {
   data?: TotalInventoryStatuses;

--- a/web/src/components/views/statusView.tsx
+++ b/web/src/components/views/statusView.tsx
@@ -24,7 +24,7 @@ const StatusView: React.FC<StatusViewProps> = ({ data }) => {
       <Typography>Inventory Status</Typography>
       {data?.map((item, index) => {
         return (
-          <Box id={index.toString()}>
+          <Box id={index.toString()} key={index}>
             <StatusItem statusTotal={item.total} statusType={item.status} />
           </Box>
         );

--- a/web/src/components/views/statusView.tsx
+++ b/web/src/components/views/statusView.tsx
@@ -10,25 +10,17 @@ interface StatusViewProps {
   data: TotalInventoryStatuses | undefined;
 };
 
-const testData: TotalInventoryStatuses = [
-  { status: Status.UNKNOWN, total: 0 },
-  { status: Status.UNSERVICEABLE, total: 1 },
-  { status: Status.IN_MAINTAINCE, total: 2 },
-  { status: Status.SERVICEABLE, total: 3 },
-];
-
 const StatusView: React.FC<StatusViewProps> = ({ data }) => {
-  data = testData; // TODO: Remove once done
   return (
     <Box sx={{ display: "flex", flexDirection: "row" }}>
       <Typography>Inventory Status</Typography>
-      {data?.map((item, index) => {
-        return (
+      {Object.values(Status)
+        .map<[Status, number | undefined]>((status) => [status, data?.[status]])
+        .map(([status, total], index) => (
           <Box id={index.toString()} key={index}>
-            <StatusItem statusTotal={item.total} statusType={item.status} />
+            <StatusItem statusTotal={total} statusType={status} />
           </Box>
-        );
-      })}
+      ))}
     </Box>
   );
 };

--- a/web/src/components/views/statusView.tsx
+++ b/web/src/components/views/statusView.tsx
@@ -7,10 +7,10 @@ import {
 } from "../../utils/types/attributes";
 
 type StatusViewProps = {
-  data?: TotalInventoryStatuses;
+  data: TotalInventoryStatuses | undefined;
 };
 
-const testData = [
+const testData: TotalInventoryStatuses = [
   { status: Status.UNKNOWN, total: 0 },
   { status: Status.UNSERVICEABLE, total: 1 },
   { status: Status.IN_MAINTAINCE, total: 2 },
@@ -18,10 +18,11 @@ const testData = [
 ];
 
 const StatusView: React.FC<StatusViewProps> = ({ data }) => {
+  data = testData; // TODO: Remove once done
   return (
     <Box sx={{ display: "flex", flexDirection: "row" }}>
       <Typography>Inventory Status</Typography>
-      {testData.map((item, index) => {
+	  {data?.map((item, index) => {
         return (
           <Box id={index.toString()}>
             <StatusItem statusTotal={item.total} statusType={item.status} />

--- a/web/src/context/auth.context.tsx
+++ b/web/src/context/auth.context.tsx
@@ -55,7 +55,6 @@ const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
       }
       if (activeUser.expiry < now + 30) {
         // Access will expire within 30 seconds. Refreshing
-		console.log("Refreshing");
         const newAuthData: AuthData = await refreshToken(activeUser)
         return authDispatch({ type: AuthOption.LOGIN, payload: newAuthData });
       }

--- a/web/src/context/auth.context.tsx
+++ b/web/src/context/auth.context.tsx
@@ -53,13 +53,14 @@ const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
         logout();
         return;
       }
-      if (activeUser.expiry < now) {
-        // Access expired. Refreshing
+      if (activeUser.expiry < now + 30) {
+        // Access will expire within 30 seconds. Refreshing
+		console.log("Refreshing");
         const newAuthData: AuthData = await refreshToken(activeUser)
         return authDispatch({ type: AuthOption.LOGIN, payload: newAuthData });
       }
     };
-    const interval = setInterval(tokenMonitor, 60*1000);
+    const interval = setInterval(tokenMonitor, 5000);
     return () => clearInterval(interval);
   }, [activeUser, logout]);
 

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -5,7 +5,7 @@ import {
   GenericClaimStructure,
 } from "../utils/types/authTypes";
 
-const API_URL = "http://localhost:3000";
+export const API_URL = "http://localhost:3000";
 
 export interface UserLoginData {
   username: string;
@@ -13,13 +13,18 @@ export interface UserLoginData {
   mfaCode: string;
 }
 
-export const fetcher = (url: string, auth: AuthData): Promise<any> =>
-  fetch(`${API_URL}${url}`, {
+export const fetcher = async <T>(url: string, auth: AuthData): Promise<T> => {
+  const response = await fetch(`${API_URL}${url}`, {
     headers: {
       Authorization: `Bearer ${auth.accessToken}`,
       "Content-Type": "application/json",
     },
-  }).then((res) => res.json());
+  });
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+  return response.json();
+}
 
 export const loginUser = async (userData: UserLoginData): Promise<Tokens> => {
   const res = await fetch(`${API_URL}/auth/login`, {

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -5,7 +5,7 @@ import {
   GenericClaimStructure,
 } from "../utils/types/authTypes";
 
-export const API_URL = "http://localhost:3000";
+const API_URL = "http://localhost:3000";
 
 export interface UserLoginData {
   username: string;
@@ -23,7 +23,7 @@ export const fetcher = async <T>(url: string, auth: AuthData): Promise<T> => {
   if (!response.ok) {
     throw new Error(response.statusText);
   }
-  return response.json();
+  return response.json() as Promise<T>;
 }
 
 export const loginUser = async (userData: UserLoginData): Promise<Tokens> => {

--- a/web/src/hooks/useAuthFetcher.ts
+++ b/web/src/hooks/useAuthFetcher.ts
@@ -1,7 +1,7 @@
 import useSWR, { SWRResponse } from "swr";
 import { useAuthContext } from "../context/auth.context";
 import { fetcher } from "../data/api";
-import type { AssetStoredAttributes } from "../utils/types/attributes";
+import type { AssetStoredAttributes, PaginationResult } from "../utils/types/attributes";
 
 export const useAuthFetcher = <T>(url: string): SWRResponse<T> => {
   const { authState } = useAuthContext();
@@ -12,4 +12,7 @@ export const useAuthFetcher = <T>(url: string): SWRResponse<T> => {
   return useSWR(url, (url) => fetcher<T>(url, authState.data));
 };
 
-export const useAssets = () => useAuthFetcher<AssetStoredAttributes[]>("/assets");
+export const useAssets = (page: number, pageSize: number) => {
+  const url = `/assets?page=${page}&pageSize=${pageSize}`;
+  return useAuthFetcher<PaginationResult<AssetStoredAttributes>>(url);
+};

--- a/web/src/hooks/useAuthFetcher.ts
+++ b/web/src/hooks/useAuthFetcher.ts
@@ -1,6 +1,7 @@
 import useSWR, { SWRResponse } from "swr";
 import { useAuthContext } from "../context/auth.context";
 import { fetcher } from "../data/api";
+import type { AssetStoredAttributes } from "../utils/types/attributes";
 
 export const useAuthFetcher = <T>(url: string): SWRResponse<T> => {
   const { authState } = useAuthContext();
@@ -8,5 +9,7 @@ export const useAuthFetcher = <T>(url: string): SWRResponse<T> => {
     throw new Error("No valid token");
   }
 
-  return useSWR(url, (url) => fetcher(url, authState.data));
+  return useSWR(url, (url) => fetcher<T>(url, authState.data));
 };
+
+export const useAssets = () => useAuthFetcher<AssetStoredAttributes[]>("/assets");

--- a/web/src/hooks/useAuthFetcher.ts
+++ b/web/src/hooks/useAuthFetcher.ts
@@ -1,7 +1,7 @@
 import useSWR, { SWRResponse } from "swr";
 import { useAuthContext } from "../context/auth.context";
 import { fetcher } from "../data/api";
-import type { AssetStoredAttributes, PaginationResult } from "../utils/types/attributes";
+import type { AssetStoredAttributes, PaginationResult, DashboardData } from "../utils/types/attributes";
 
 export const useAuthFetcher = <T>(url: string): SWRResponse<T> => {
   const { authState } = useAuthContext();
@@ -16,3 +16,5 @@ export const useAssets = (page: number, pageSize: number) => {
   const url = `/assets?page=${page}&pageSize=${pageSize}`;
   return useAuthFetcher<PaginationResult<AssetStoredAttributes>>(url);
 };
+
+export const useDashboardData = () => useAuthFetcher<DashboardData>("/dashboard");

--- a/web/src/hooks/useAuthFetcher.ts
+++ b/web/src/hooks/useAuthFetcher.ts
@@ -3,7 +3,7 @@ import { useAuthContext } from "../context/auth.context";
 import { fetcher } from "../data/api";
 import type { AssetStoredAttributes, PaginationResult, DashboardData } from "../utils/types/attributes";
 
-export const useAuthFetcher = <T>(url: string): SWRResponse<T> => {
+const useAuthFetcher = <T>(url: string): SWRResponse<T> => {
   const { authState } = useAuthContext();
   if (!authState.isLoggedIn) {
     throw new Error("No valid token");

--- a/web/src/pages/assets/Assets.tsx
+++ b/web/src/pages/assets/Assets.tsx
@@ -6,7 +6,9 @@ import type { AssetStoredAttributes } from "../../utils/types/attributes";
 
 function Assets() {
   const { data, error } = useAssets(1, 25);
-  if (error !== undefined && typeof error === "string") throw new Error(error);
+  if (error !== undefined) {
+    console.error(error);
+  }
   if (data === undefined) return <Skeleton />;
   return (
     <Layout>

--- a/web/src/pages/assets/Assets.tsx
+++ b/web/src/pages/assets/Assets.tsx
@@ -1,38 +1,30 @@
-import { Box, TableRow, TableCell } from "@mui/material";
+import { Box, TableRow, TableCell, Skeleton } from "@mui/material";
 import PaginatedTable from "../../components/table/PaginatedTable.component";
 import Layout from "../../components/layout/Layout";
-
-// Demonstration of what table needs
-interface AssetData {
-  id: number;
-  field1: string;
-  field2: `${boolean}`;
-}
-const sampleData: AssetData[] = [
-  { id: 1, field1: "Value1", field2: "true" },
-  { id: 2, field1: "Other Value", field2: "false" },
-];
+import { useAssets } from "../../hooks/useAuthFetcher";
+import type { AssetStoredAttributes } from "../../utils/types/attributes";
 
 function Assets() {
-  for (let i = 0; i < 30; i++) {
-    // Sample code, so is fine to have a non-null assertion, since array is defined above
-    const data = { ...sampleData[1]!, id: i + 3 };
-    sampleData.push(data);
-  }
+  const { data, error } = useAssets();
+  if (error !== undefined) throw new Error(error);
+  if (data === undefined) return <Skeleton />;
   return (
     <Layout>
       <Box style={{ width: "100vw", height: "95vh" }}>
         <h1 style={{ marginLeft: "5%" }}>Assets</h1>
         <Box style={{ height: "80%", marginLeft: "5vw", marginRight: "5vw" }}>
-          <AssetsTable data={sampleData} />
+          <AssetsTable data={data} />
         </Box>
       </Box>
     </Layout>
   );
 }
 
-function renderAssetRow(datum: AssetData) {
-  const { id, field1, field2 } = datum;
+function renderAssetRow(datum: AssetStoredAttributes) {
+  //const { id, field1, field2 } = datum;
+  const { id } = datum;
+  const field1 = "TODO";
+  const field2 = "TODO";
   return (
     <TableRow>
       <TableCell sx={{ border: "1px solid white" }}>{id}</TableCell>
@@ -53,7 +45,7 @@ function renderAssetHeaders() {
 }
 
 interface AssetsTableProps {
-  data: AssetData[];
+  data: AssetStoredAttributes[];
 }
 
 function AssetsTable({ data }: AssetsTableProps) {

--- a/web/src/pages/assets/Assets.tsx
+++ b/web/src/pages/assets/Assets.tsx
@@ -5,15 +5,15 @@ import { useAssets } from "../../hooks/useAuthFetcher";
 import type { AssetStoredAttributes } from "../../utils/types/attributes";
 
 function Assets() {
-  const { data, error } = useAssets();
-  if (error !== undefined) throw new Error(error);
+  const { data, error } = useAssets(1, 25);
+  if (error !== undefined && typeof error === "string") throw new Error(error);
   if (data === undefined) return <Skeleton />;
   return (
     <Layout>
       <Box style={{ width: "100vw", height: "95vh" }}>
         <h1 style={{ marginLeft: "5%" }}>Assets</h1>
         <Box style={{ height: "80%", marginLeft: "5vw", marginRight: "5vw" }}>
-          <AssetsTable data={data} />
+          <AssetsTable data={data.data} />
         </Box>
       </Box>
     </Layout>
@@ -21,15 +21,14 @@ function Assets() {
 }
 
 function renderAssetRow(datum: AssetStoredAttributes) {
-  //const { id, field1, field2 } = datum;
-  const { id } = datum;
-  const field1 = "TODO";
-  const field2 = "TODO";
+  const { id, name, modelNumber, status } = datum;
   return (
     <TableRow>
-      <TableCell sx={{ border: "1px solid white" }}>{id}</TableCell>
-      <TableCell sx={{ border: "1px solid white" }}>{field1}</TableCell>
-      <TableCell sx={{ border: "1px solid white" }}>{field2}</TableCell>
+      <TableCell sx={{ border: "1px solid grey" }}>{id}</TableCell>
+      <TableCell sx={{ border: "1px solid grey" }}>{name}</TableCell>
+      <TableCell sx={{ border: "1px solid grey" }}>{modelNumber}</TableCell>
+      <TableCell sx={{ border: "1px solid grey" }}>{status}</TableCell>
+      <TableCell sx={{ border: "1px solid grey" }}>{datum.createdAt?.toString()}</TableCell>
     </TableRow>
   );
 }
@@ -37,9 +36,11 @@ function renderAssetRow(datum: AssetStoredAttributes) {
 function renderAssetHeaders() {
   return (
     <TableRow>
-      <th style={{ border: "1px solid white" }}>id</th>
-      <th style={{ border: "1px solid white" }}>field1</th>
-      <th style={{ border: "1px solid white" }}>field2</th>
+      <th style={{ border: "1px solid grey" }}>id</th>
+      <th style={{ border: "1px solid grey" }}>name</th>
+      <th style={{ border: "1px solid grey" }}>modelNumber</th>
+      <th style={{ border: "1px solid grey" }}>status</th>
+      <th style={{ border: "1px solid grey" }}>createdAt</th>
     </TableRow>
   );
 }

--- a/web/src/pages/dashboard/Dashboard.tsx
+++ b/web/src/pages/dashboard/Dashboard.tsx
@@ -19,7 +19,7 @@ function HomePage() {
         </Typography>
       </Box>
       <Divider variant="middle" />
-      <ChartView data={data?.totalInventoryCount ?? []} />
+      <ChartView data={data?.totalInventoryCount} />
       <Box>
         <StatusView data={data?.totalInventoryStatuses} />
       </Box>

--- a/web/src/pages/dashboard/Dashboard.tsx
+++ b/web/src/pages/dashboard/Dashboard.tsx
@@ -3,15 +3,14 @@ import { useAuthContext } from "../../context/auth.context";
 import Layout from "../../components/layout/Layout";
 import ChartView from "../../components/ui/chartView";
 import { Box, Divider, Typography } from "@mui/material";
-import { DashboardData } from "../../../../api/src/utils/types/attributeTypes";
-import { useAuthFetcher } from "../../hooks/useAuthFetcher";
+import { useDashboardData } from "../../hooks/useAuthFetcher";
 import StatusView from "../../components/views/statusView";
 
 function HomePage() {
   const { authState } = useAuthContext();
   if (!authState.isLoggedIn) return <Navigate to="/login" />;
 
-  const { data } = useAuthFetcher<DashboardData>("/dashboard");
+  const { data } = useDashboardData();
   
   return (
     <Layout>

--- a/web/src/pages/dashboard/Dashboard.tsx
+++ b/web/src/pages/dashboard/Dashboard.tsx
@@ -8,9 +8,8 @@ import StatusView from "../../components/views/statusView";
 
 function HomePage() {
   const { authState } = useAuthContext();
-  if (!authState.isLoggedIn) return <Navigate to="/login" />;
-
   const { data } = useDashboardData();
+  if (!authState.isLoggedIn) return <Navigate to="/login" />;
   
   return (
     <Layout>
@@ -20,9 +19,9 @@ function HomePage() {
         </Typography>
       </Box>
       <Divider variant="middle" />
-      <ChartView data={data?.totalInventoryCount || []} />
+      <ChartView data={data?.totalInventoryCount ?? []} />
       <Box>
-        <StatusView />
+        <StatusView data={data?.totalInventoryStatuses} />
       </Box>
     </Layout>
   );

--- a/web/src/utils/types/attributes.ts
+++ b/web/src/utils/types/attributes.ts
@@ -66,7 +66,7 @@ export type TotalInventoryCount = {
   assets: number;
 };
 
-export type TotalInventoryStatuses = Array<{ status: Status, total: number }>;
+export type TotalInventoryStatuses = Record<Status, number>;
 export type RecentlyAddedInventory = AssetStoredAttributes[];
 
 export type DashboardData = {

--- a/web/src/utils/types/attributes.ts
+++ b/web/src/utils/types/attributes.ts
@@ -71,6 +71,6 @@ export type RecentlyAddedInventory = AssetStoredAttributes[];
 
 export type DashboardData = {
   totalInventoryCount: TotalInventoryCount[];
-  totalInventoryStatuses: TotalInventoryStatuses[];
+  totalInventoryStatuses: TotalInventoryStatuses;
   recentlyAddedInventory: RecentlyAddedInventory;
 };

--- a/web/src/utils/types/attributes.ts
+++ b/web/src/utils/types/attributes.ts
@@ -70,7 +70,7 @@ export type TotalInventoryStatuses = Array<{ status: Status, total: number }>;
 export type RecentlyAddedInventory = AssetStoredAttributes[];
 
 export type DashboardData = {
-  totalInventoryCount: TotalInventoryCount[];
+  totalInventoryCount: TotalInventoryCount;
   totalInventoryStatuses: TotalInventoryStatuses;
   recentlyAddedInventory: RecentlyAddedInventory;
 };

--- a/web/src/utils/types/attributes.ts
+++ b/web/src/utils/types/attributes.ts
@@ -1,0 +1,56 @@
+import type { UUID, Scope } from "./authTypes";
+
+export interface AssetCreationAttributes {
+  assetTag: string;
+  name: string;
+  serialNumber?: string;
+  modelNumber?: string;
+  status: Status;
+  nextAuditDate?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface UserCreationAttributes {
+  firstName: string;
+  lastName: string;
+  username: string;
+  password: string;
+  email: string;
+  isActive: boolean;
+  scope: Scope[];
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface LocationCreationAttributes {
+  locationName: string;
+  geoLocation?: JSON;
+  primaryLocation: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+// Convert optional properties from `[K]?: T` or `[K]: T | undefined`, into `[K]: T | null`.
+type StoredAttributes<TCreation> = { id: number } & {
+  [K in keyof TCreation]-?: undefined extends TCreation[K]
+    ? Exclude<TCreation[K], undefined> | null
+    : TCreation[K];
+};
+
+export interface AssetStoredAttributes
+  extends StoredAttributes<AssetCreationAttributes> {}
+export interface UserStoredAttributes
+  extends StoredAttributes<UserCreationAttributes> {
+  mfaSecret: string | null;
+  uuid: UUID;
+}
+export interface LocationStoredAttributes
+  extends StoredAttributes<LocationCreationAttributes> {}
+
+export enum Status {
+  SERVICEABLE = "SERVICEABLE",
+  IN_MAINTAINCE = "IN_MAINTAINCE",
+  UNSERVICEABLE = "UNSERVICEABLE",
+  UNKNOWN = "UNKNOWN",
+}

--- a/web/src/utils/types/attributes.ts
+++ b/web/src/utils/types/attributes.ts
@@ -54,3 +54,12 @@ export enum Status {
   UNSERVICEABLE = "UNSERVICEABLE",
   UNKNOWN = "UNKNOWN",
 }
+
+export type PaginationResult<T> = {
+    lastPage: number;
+    totalRecords: number;
+    hasMorePages: boolean;
+    data: T[];
+};
+
+

--- a/web/src/utils/types/attributes.ts
+++ b/web/src/utils/types/attributes.ts
@@ -62,4 +62,15 @@ export type PaginationResult<T> = {
     data: T[];
 };
 
+export type TotalInventoryCount = {
+  assets: number;
+};
 
+export type TotalInventoryStatuses = Array<{ status: Status, total: number }>;
+export type RecentlyAddedInventory = AssetStoredAttributes[];
+
+export type DashboardData = {
+  totalInventoryCount: TotalInventoryCount[];
+  totalInventoryStatuses: TotalInventoryStatuses[];
+  recentlyAddedInventory: RecentlyAddedInventory;
+};

--- a/web/src/utils/types/authTypes.ts
+++ b/web/src/utils/types/authTypes.ts
@@ -1,4 +1,5 @@
 export type UUID = `${string}-${string}-${string}-${string}-${string}`;
+export type Scope = string;
 
 export enum AuthOption {
   LOGIN = "LOGIN",


### PR DESCRIPTION
## API
- Updated type from `Asset` to `AssetStoredAttributes`.

## Web
- Updated types to not refer to files within `api`, instead duplicating types to be factored out in #6 .
- Changed token refresh to occur 30 seconds prior to expiry since it was causing authentication issues with data fetching, and increased frequency of checks from 60s to 5s.
- Added hooks for `useAssets` and `useDashboardData` to encapsulate types and url, to ensure they are consistent, and provide a reduced location for all api access.
- Updated `Asset` table from showing demo data, to showing fetched data from API.