### PR TITLE
Web Data Validators

### DIFF
--- a/trace-common/src/schemas.ts
+++ b/trace-common/src/schemas.ts
@@ -1,11 +1,12 @@
 import { ZodSchema, z} from "zod";
 
 import { AssetCreationAttributes, UserCreationAttributes, Scope, LocationCreationAttributes, Status } from "./attributeTypes";
-import { AccessTokenPayload, IdTokenPayload, RefreshTokenPayload, TokenUse, UserLogin } from "./authenticationTypes";
+import { AccessTokenPayload, GenericClaimStructure, IdTokenPayload, RefreshTokenPayload, TokenUse, UserLogin } from "./authenticationTypes";
 import { parseMFACode } from "./validator";
+import type { UUID } from "./misc";
 import "./ZodExtend";
 
-export const assetCreationSchema: ZodSchema<AssetCreationAttributes> = z.object({
+export const assetCreationSchema = z.object({
   assetTag: z.string(),
   name: z.string(),
   serialNumber: z.string().optional(),
@@ -14,9 +15,9 @@ export const assetCreationSchema: ZodSchema<AssetCreationAttributes> = z.object(
   nextAuditDate: z.coerce.date().optional(),
   createdAt: z.coerce.date().optional(),
   updatedAt: z.coerce.date().optional(),
-}).strict().exactOptions();
+}).strict().exactOptions() satisfies ZodSchema<AssetCreationAttributes>;
 
-export const userCreationSchema: ZodSchema<UserCreationAttributes> = z.object({
+export const userCreationSchema = z.object({
   firstName: z.string(),
   lastName: z.string(),
   username: z.string(),
@@ -26,15 +27,15 @@ export const userCreationSchema: ZodSchema<UserCreationAttributes> = z.object({
   scope: z.array(z.nativeEnum(Scope)),
   createdAt: z.coerce.date().optional(),
   updatedAt: z.coerce.date().optional(),
-}).strict().exactOptions();
+}).strict().exactOptions() satisfies ZodSchema<UserCreationAttributes>;
 
-export const locationCreationSchema: ZodSchema<LocationCreationAttributes> = z.object({
+export const locationCreationSchema = z.object({
   locationName: z.string(),
   geoLocation: z.any().optional(),
   primaryLocation: z.boolean(),
   createdAt: z.coerce.date().optional(),
   updatedAt: z.coerce.date().optional(),
-}).strict().exactOptions();
+}).strict().exactOptions() satisfies ZodSchema<LocationCreationAttributes>;
 
 export const mfaCodeSchema = z.union([
   z.string().length(6).refine((val) => /^[0-9]*$/.test(val)),
@@ -43,25 +44,34 @@ export const mfaCodeSchema = z.union([
   }).strict(),
 ]);
 
-export const userLoginSchema: ZodSchema<UserLogin> = z.object({
+export const userLoginSchema = z.object({
   username: z.string(),
   password: z.string(),
   mfaCode: z.string().refine((val) => parseMFACode(val)).optional(),
-}).strict().exactOptions();
+}).strict().exactOptions() satisfies ZodSchema<UserLogin>;
 
-export const refreshTokenPayloadSchema: ZodSchema<RefreshTokenPayload> = z.object({
+export const refreshTokenPayloadSchema = z.object({
 	token_use: z.literal(TokenUse.Refresh),
 	username: z.string(),
-}).strict();
+}).strict() satisfies ZodSchema<RefreshTokenPayload>;
 
-export const accessTokenPayloadSchema: ZodSchema<AccessTokenPayload> = z.object({
+export const accessTokenPayloadSchema = z.object({
 	token_use: z.literal(TokenUse.Access),
 	scope: z.nativeEnum(Scope).array(),
-}).strict();
+}).strict() satisfies ZodSchema<AccessTokenPayload>;
 
-export const idTokenPayloadSchema: ZodSchema<IdTokenPayload> = z.object({
+export const idTokenPayloadSchema = z.object({
 	token_use: z.literal(TokenUse.Id),
 	firstname: z.string(),
 	lastname: z.string(),
 	email: z.string(),
-}).strict();
+}).strict() satisfies ZodSchema<IdTokenPayload>;
+
+export const genericClaimStructureSchema = z.object({
+	iss: z.string(),
+	sub: z.string().uuid() as ZodSchema<UUID>,
+	aud: z.string(),
+	exp: z.number(),
+	iat: z.number(),
+	token_use: z.nativeEnum(TokenUse),
+}).strict() satisfies ZodSchema<GenericClaimStructure>;

--- a/trace-common/src/schemas.ts
+++ b/trace-common/src/schemas.ts
@@ -1,7 +1,7 @@
 import { ZodSchema, z} from "zod";
 
 import { AssetCreationAttributes, UserCreationAttributes, Scope, LocationCreationAttributes, Status } from "./attributeTypes";
-import { AccessTokenPayload, GenericClaimStructure, IdTokenPayload, RefreshTokenPayload, TokenUse, UserLogin } from "./authenticationTypes";
+import { AccessTokenPayload, GenericClaimStructure, IdTokenPayload, RefreshTokenPayload, TokenUse, UserLogin, Tokens } from "./authenticationTypes";
 import { parseMFACode } from "./validator";
 import type { UUID } from "./misc";
 import "./ZodExtend";
@@ -51,27 +51,33 @@ export const userLoginSchema = z.object({
 }).strict().exactOptions() satisfies ZodSchema<UserLogin>;
 
 export const refreshTokenPayloadSchema = z.object({
-	token_use: z.literal(TokenUse.Refresh),
-	username: z.string(),
+  token_use: z.literal(TokenUse.Refresh),
+  username: z.string(),
 }).strict() satisfies ZodSchema<RefreshTokenPayload>;
 
 export const accessTokenPayloadSchema = z.object({
-	token_use: z.literal(TokenUse.Access),
-	scope: z.nativeEnum(Scope).array(),
+  token_use: z.literal(TokenUse.Access),
+  scope: z.nativeEnum(Scope).array(),
 }).strict() satisfies ZodSchema<AccessTokenPayload>;
 
 export const idTokenPayloadSchema = z.object({
-	token_use: z.literal(TokenUse.Id),
-	firstname: z.string(),
-	lastname: z.string(),
-	email: z.string(),
+  token_use: z.literal(TokenUse.Id),
+  firstname: z.string(),
+  lastname: z.string(),
+  email: z.string(),
 }).strict() satisfies ZodSchema<IdTokenPayload>;
 
 export const genericClaimStructureSchema = z.object({
-	iss: z.string(),
-	sub: z.string().uuid() as ZodSchema<UUID>,
-	aud: z.string(),
-	exp: z.number(),
-	iat: z.number(),
-	token_use: z.nativeEnum(TokenUse),
+  iss: z.string(),
+  sub: z.string().uuid() as ZodSchema<UUID>,
+  aud: z.string(),
+  exp: z.number(),
+  iat: z.number(),
+  token_use: z.nativeEnum(TokenUse),
 }).strict() satisfies ZodSchema<GenericClaimStructure>;
+
+export const tokensSchema = z.object({
+  accessToken: z.string(),
+  idToken: z.string(),
+  refreshToken: z.string(),
+}).strict() satisfies ZodSchema<Tokens>;

--- a/trace-common/src/schemas.ts
+++ b/trace-common/src/schemas.ts
@@ -1,7 +1,7 @@
 import { ZodSchema, z} from "zod";
 
 import { AssetCreationAttributes, UserCreationAttributes, Scope, LocationCreationAttributes, Status } from "./attributeTypes";
-import { UserLogin } from "./authenticationTypes";
+import { AccessTokenPayload, IdTokenPayload, RefreshTokenPayload, TokenUse, UserLogin } from "./authenticationTypes";
 import { parseMFACode } from "./validator";
 import "./ZodExtend";
 
@@ -48,3 +48,20 @@ export const userLoginSchema: ZodSchema<UserLogin> = z.object({
   password: z.string(),
   mfaCode: z.string().refine((val) => parseMFACode(val)).optional(),
 }).strict().exactOptions();
+
+export const refreshTokenPayloadSchema: ZodSchema<RefreshTokenPayload> = z.object({
+	token_use: z.literal(TokenUse.Refresh),
+	username: z.string(),
+}).strict();
+
+export const accessTokenPayloadSchema: ZodSchema<AccessTokenPayload> = z.object({
+	token_use: z.literal(TokenUse.Access),
+	scope: z.nativeEnum(Scope).array(),
+}).strict();
+
+export const idTokenPayloadSchema: ZodSchema<IdTokenPayload> = z.object({
+	token_use: z.literal(TokenUse.Id),
+	firstname: z.string(),
+	lastname: z.string(),
+	email: z.string(),
+}).strict();

--- a/trace-common/src/validator.ts
+++ b/trace-common/src/validator.ts
@@ -1,7 +1,9 @@
 import type { ZodSchema } from "zod";
-import { mfaCodeSchema, assetCreationSchema, userCreationSchema, locationCreationSchema, userLoginSchema } from "./schemas";
+import {
+  mfaCodeSchema, assetCreationSchema, userCreationSchema, locationCreationSchema, userLoginSchema,
+  idTokenPayloadSchema, accessTokenPayloadSchema, refreshTokenPayloadSchema } from "./schemas";
 import type { AssetCreationAttributes, UserCreationAttributes, LocationCreationAttributes } from "./attributeTypes";
-import type { UserLogin } from "./authenticationTypes";
+import type { AccessTokenPayload, IdTokenPayload, RefreshTokenPayload, UserLogin } from "./authenticationTypes";
 
 const validate = <T>(data: unknown, schema: ZodSchema<T>): T => {
   const result = schema.safeParse(data);
@@ -17,6 +19,9 @@ export const validateAsset: Validator<AssetCreationAttributes> = (data: unknown)
 export const validateUser: Validator<UserCreationAttributes> = (data: unknown) => validate<UserCreationAttributes>(data, userCreationSchema);
 export const validateLocation: Validator<LocationCreationAttributes> = (data: unknown) => validate<LocationCreationAttributes>(data, locationCreationSchema);
 export const validateUserLogin: Validator<UserLogin> = (data: unknown) => validate<UserLogin>(data, userLoginSchema);
+export const validateIdTokenPayload: Validator<IdTokenPayload> = (data: unknown) => validate<IdTokenPayload>(data, idTokenPayloadSchema);
+export const validateAccessTokenPayload: Validator<AccessTokenPayload> = (data: unknown) => validate<AccessTokenPayload>(data, accessTokenPayloadSchema);
+export const validateRefreshTokenPayload: Validator<RefreshTokenPayload> = (data: unknown) => validate<RefreshTokenPayload>(data, refreshTokenPayloadSchema);
 
 // Checks for either a string literal, or an object of type `{ code: string }`.
 export const parseMFACode: Validator<string> = (data: unknown): string => {

--- a/trace-common/src/validator.ts
+++ b/trace-common/src/validator.ts
@@ -1,9 +1,10 @@
 import type { ZodSchema } from "zod";
 import {
   mfaCodeSchema, assetCreationSchema, userCreationSchema, locationCreationSchema, userLoginSchema,
-  idTokenPayloadSchema, accessTokenPayloadSchema, refreshTokenPayloadSchema } from "./schemas";
+  idTokenPayloadSchema, accessTokenPayloadSchema, refreshTokenPayloadSchema, 
+  genericClaimStructureSchema} from "./schemas";
 import type { AssetCreationAttributes, UserCreationAttributes, LocationCreationAttributes } from "./attributeTypes";
-import type { AccessTokenPayload, IdTokenPayload, RefreshTokenPayload, UserLogin } from "./authenticationTypes";
+import type { AccessTokenPayload, GenericClaimStructure, IdTokenPayload, RefreshTokenPayload, UserLogin } from "./authenticationTypes";
 
 const validate = <T>(data: unknown, schema: ZodSchema<T>): T => {
   const result = schema.safeParse(data);
@@ -22,6 +23,13 @@ export const validateUserLogin: Validator<UserLogin> = (data: unknown) => valida
 export const validateIdTokenPayload: Validator<IdTokenPayload> = (data: unknown) => validate<IdTokenPayload>(data, idTokenPayloadSchema);
 export const validateAccessTokenPayload: Validator<AccessTokenPayload> = (data: unknown) => validate<AccessTokenPayload>(data, accessTokenPayloadSchema);
 export const validateRefreshTokenPayload: Validator<RefreshTokenPayload> = (data: unknown) => validate<RefreshTokenPayload>(data, refreshTokenPayloadSchema);
+
+export const validateIdToken: Validator<IdTokenPayload & GenericClaimStructure> =
+  (data: unknown) => validate<IdTokenPayload & GenericClaimStructure>(data, genericClaimStructureSchema.extend(idTokenPayloadSchema.shape));
+export const validateAccessToken: Validator<AccessTokenPayload & GenericClaimStructure> =
+  (data: unknown) => validate<AccessTokenPayload & GenericClaimStructure>(data, genericClaimStructureSchema.extend(accessTokenPayloadSchema.shape));
+export const validateRefreshToken: Validator<RefreshTokenPayload & GenericClaimStructure> =
+  (data: unknown) => validate<RefreshTokenPayload & GenericClaimStructure>(data, genericClaimStructureSchema.extend(refreshTokenPayloadSchema.shape));
 
 // Checks for either a string literal, or an object of type `{ code: string }`.
 export const parseMFACode: Validator<string> = (data: unknown): string => {

--- a/trace-common/src/validator.ts
+++ b/trace-common/src/validator.ts
@@ -7,7 +7,7 @@ import {
 import type { AssetCreationAttributes, UserCreationAttributes, LocationCreationAttributes } from "./attributeTypes";
 import type { AccessTokenPayload, GenericClaimStructure, IdTokenPayload, RefreshTokenPayload, Tokens, UserLogin } from "./authenticationTypes";
 
-const validate = <T>(data: unknown, schema: ZodSchema<T>): T => {
+export const validate = <T>(data: unknown, schema: ZodSchema<T>): T => {
   const result = schema.safeParse(data);
   if (!result.success) {
     throw result.error;

--- a/trace-common/src/validator.ts
+++ b/trace-common/src/validator.ts
@@ -2,9 +2,10 @@ import type { ZodSchema } from "zod";
 import {
   mfaCodeSchema, assetCreationSchema, userCreationSchema, locationCreationSchema, userLoginSchema,
   idTokenPayloadSchema, accessTokenPayloadSchema, refreshTokenPayloadSchema, 
-  genericClaimStructureSchema} from "./schemas";
+  genericClaimStructureSchema,
+  tokensSchema} from "./schemas";
 import type { AssetCreationAttributes, UserCreationAttributes, LocationCreationAttributes } from "./attributeTypes";
-import type { AccessTokenPayload, GenericClaimStructure, IdTokenPayload, RefreshTokenPayload, UserLogin } from "./authenticationTypes";
+import type { AccessTokenPayload, GenericClaimStructure, IdTokenPayload, RefreshTokenPayload, Tokens, UserLogin } from "./authenticationTypes";
 
 const validate = <T>(data: unknown, schema: ZodSchema<T>): T => {
   const result = schema.safeParse(data);
@@ -20,6 +21,7 @@ export const validateAsset: Validator<AssetCreationAttributes> = (data: unknown)
 export const validateUser: Validator<UserCreationAttributes> = (data: unknown) => validate<UserCreationAttributes>(data, userCreationSchema);
 export const validateLocation: Validator<LocationCreationAttributes> = (data: unknown) => validate<LocationCreationAttributes>(data, locationCreationSchema);
 export const validateUserLogin: Validator<UserLogin> = (data: unknown) => validate<UserLogin>(data, userLoginSchema);
+export const validateTokens: Validator<Tokens> = (data: unknown) => validate<Tokens>(data, tokensSchema);
 export const validateIdTokenPayload: Validator<IdTokenPayload> = (data: unknown) => validate<IdTokenPayload>(data, idTokenPayloadSchema);
 export const validateAccessTokenPayload: Validator<AccessTokenPayload> = (data: unknown) => validate<AccessTokenPayload>(data, accessTokenPayloadSchema);
 export const validateRefreshTokenPayload: Validator<RefreshTokenPayload> = (data: unknown) => validate<RefreshTokenPayload>(data, refreshTokenPayloadSchema);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,7 +19,8 @@
         "react-qr-code": "^2.0.12",
         "react-router-dom": "^6.21.3",
         "swr": "^2.2.5",
-        "trace_common": "file:../trace-common"
+        "trace_common": "file:../trace-common",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.6.1",
@@ -12605,6 +12606,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "react-qr-code": "^2.0.12",
     "react-router-dom": "^6.21.3",
     "swr": "^2.2.5",
+    "zod": "^3.23.8",
     "trace_common": "file:../trace-common"
   },
   "devDependencies": {

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -9,9 +9,9 @@ import {
 } from "../utils/types/authTypes";
 
 import {
-	validateIdTokenPayload,
-	validateAccessTokenPayload,
-	validateRefreshTokenPayload,
+	validateIdToken,
+	validateAccessToken,
+	validateRefreshToken,
 } from "../utils/validators/authValidators";
 
 const API_URL = "http://localhost:3000";
@@ -50,10 +50,9 @@ export const loginUser = async (userData: UserLoginData): Promise<Tokens> => {
 };
 
 export const decodeUserAuth = (tokens: Tokens): AuthData => {
-  // FIXME: These need to include GenericClaimStructure.
-  const idTokenPayload: IdTokenPayload = validateIdTokenPayload(decodeTokenPayload(tokens.idToken));
-  const accessTokenPayload: AccessTokenPayload = validateAccessTokenPayload(decodeTokenPayload(tokens.accessToken));
-  const refreshTokenPayload: RefreshTokenPayload = validateRefreshTokenPayload(decodeTokenPayload(tokens.refreshToken));
+  const idTokenPayload: IdTokenPayload & GenericClaimStructure = validateIdToken(decodeTokenPayload(tokens.idToken));
+  const accessTokenPayload: AccessTokenPayload & GenericClaimStructure = validateAccessToken(decodeTokenPayload(tokens.accessToken));
+  const refreshTokenPayload: RefreshTokenPayload & GenericClaimStructure = validateRefreshToken(decodeTokenPayload(tokens.refreshToken));
   return {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
@@ -88,7 +87,7 @@ export const refreshToken = async (authData: AuthData): Promise<AuthData> => {
   }
   const accessToken: string = await res.text();
   const accessTokenPayload: AccessTokenPayload & GenericClaimStructure =
-    validateAccessTokenPayload(accessToken);
+    validateAccessToken(decodeTokenPayload(accessToken));
   return {
     ...authData,
     accessToken,

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -9,9 +9,10 @@ import {
 } from "../utils/types/authTypes";
 
 import {
-	validateIdToken,
-	validateAccessToken,
-	validateRefreshToken,
+  validateTokens,
+  validateIdToken,
+  validateAccessToken,
+  validateRefreshToken,
 } from "../utils/validators/authValidators";
 
 const API_URL = "http://localhost:3000";
@@ -43,16 +44,18 @@ export const loginUser = async (userData: UserLoginData): Promise<Tokens> => {
   if (res.status !== 200) {
     throw new Error();
   }
-
-  // TODO: Validate
-  const data: Tokens = await res.json();
-  return data;
+  const data: unknown = await res.json();
+  const tokens: Tokens = validateTokens(data);
+  return tokens;
 };
 
 export const decodeUserAuth = (tokens: Tokens): AuthData => {
-  const idTokenPayload: IdTokenPayload & GenericClaimStructure = validateIdToken(decodeTokenPayload(tokens.idToken));
-  const accessTokenPayload: AccessTokenPayload & GenericClaimStructure = validateAccessToken(decodeTokenPayload(tokens.accessToken));
-  const refreshTokenPayload: RefreshTokenPayload & GenericClaimStructure = validateRefreshToken(decodeTokenPayload(tokens.refreshToken));
+  const idTokenPayload: IdTokenPayload & GenericClaimStructure =
+    validateIdToken(decodeTokenPayload(tokens.idToken));
+  const accessTokenPayload: AccessTokenPayload & GenericClaimStructure =
+    validateAccessToken(decodeTokenPayload(tokens.accessToken));
+  const refreshTokenPayload: RefreshTokenPayload & GenericClaimStructure =
+    validateRefreshToken(decodeTokenPayload(tokens.refreshToken));
   return {
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,

--- a/web/src/data/storage.ts
+++ b/web/src/data/storage.ts
@@ -1,4 +1,5 @@
 import { AuthData, AuthState } from "../utils/types/authTypes";
+import { validateAuthData } from "../utils/validators/authValidators";
 
 export const setSessionUser = (user: AuthData): void => {
   sessionStorage.setItem("trace_user", JSON.stringify(user));
@@ -7,7 +8,8 @@ export const setSessionUser = (user: AuthData): void => {
 export const getSessionUser = (): AuthData | null => {
   const item = sessionStorage.getItem("trace_user");
   if (item === null) return null;
-  return JSON.parse(item) as AuthData;
+  const authData: AuthData = validateAuthData(item);
+  return authData;
 };
 
 export const removeSessionUser = (): void => {

--- a/web/src/utils/types/authTypes.ts
+++ b/web/src/utils/types/authTypes.ts
@@ -1,4 +1,4 @@
-export type { UUID, GenericClaimStructure, Tokens, IdTokenPayload, UserLogin } from "trace_common";
+export type { UUID, GenericClaimStructure, Tokens, IdTokenPayload, AccessTokenPayload, RefreshTokenPayload, UserLogin } from "trace_common";
 
 export enum AuthOption {
   LOGIN = "LOGIN",

--- a/web/src/utils/validators/authValidators.ts
+++ b/web/src/utils/validators/authValidators.ts
@@ -1,5 +1,5 @@
 export {
-	validateIdTokenPayload,
-	validateAccessTokenPayload,
-	validateRefreshTokenPayload,
+	validateIdToken,
+	validateAccessToken,
+	validateRefreshToken,
 } from "trace_common";

--- a/web/src/utils/validators/authValidators.ts
+++ b/web/src/utils/validators/authValidators.ts
@@ -1,5 +1,6 @@
 export {
-	validateIdToken,
-	validateAccessToken,
-	validateRefreshToken,
+  validateTokens,
+  validateIdToken,
+  validateAccessToken,
+  validateRefreshToken,
 } from "trace_common";

--- a/web/src/utils/validators/authValidators.ts
+++ b/web/src/utils/validators/authValidators.ts
@@ -1,6 +1,22 @@
+import { z, ZodSchema } from "zod";
+import { validate, Validator } from "trace_common";
+import { AuthData } from "../types/authTypes";
+
 export {
   validateTokens,
   validateIdToken,
   validateAccessToken,
   validateRefreshToken,
 } from "trace_common";
+
+export const authDataSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  expiry: z.number(),
+  refreshExpiry: z.number(),
+  email: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+}).strict() satisfies ZodSchema<AuthData>;
+
+export const validateAuthData: Validator<AuthData> = (data: unknown) => validate<AuthData>(data, authDataSchema);

--- a/web/src/utils/validators/authValidators.ts
+++ b/web/src/utils/validators/authValidators.ts
@@ -1,0 +1,5 @@
+export {
+	validateIdTokenPayload,
+	validateAccessTokenPayload,
+	validateRefreshTokenPayload,
+} from "trace_common";


### PR DESCRIPTION
- Define several new schemas and validation functions within `trace_common`.
- Reduce the type assertions within the `web` package, to use validation schemas from `trace_common` package.
- Replace typesafe assignments that degrade the type of the schema to `ZodSchema<T>`, into using `satisfies` to retain the original type, but still check the type requirement.
- Adds `zod` as dependency to `web`, to validate `AuthData`.